### PR TITLE
ci(termux): refactor standalone release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/release-template.md
+++ b/.github/release-template.md
@@ -1,0 +1,31 @@
+Automated standalone Termux build of the Antigravity CLI v{{VERSION}}.
+
+> [!IMPORTANT]
+> **Twin-Binary Requirement:** The release package contains **two** binaries: `bin/agy` and `bin/agy.va39`.
+> * `bin/agy.va39` is the core patched engine.
+> * `bin/agy` is the native Bionic C bootstrapper.
+> **Always execute the `./bin/agy` binary.** It automatically clears conflicts and executes the core engine. You **must** keep both files in the same directory for the bootstrapper to run successfully.
+
+### 🔀 Standalone Fork Changelog
+{{FORK_CHANGELOG}}
+
+### ⬆️ Upstream Changelog (v{{VERSION}})
+
+{{UPSTREAM_NOTES}}
+
+### 📦 Installation
+To install this release, extract the package to your preferred location (e.g. `~/.local` or a sandbox folder) and execute the C helper directly:
+```bash
+# 1. Download and extract
+curl -fsSLO https://github.com/{{REPO}}/releases/download/v{{VERSION}}/antigravity-termux-standalone.tar.gz
+tar -xzf antigravity-termux-standalone.tar.gz
+
+# 2. Run immediately without shell configuration or wrappers!
+./bin/agy --help
+```
+
+### 🔒 Cryptographic Verification
+This release is signed with cryptographic build provenance. Verify it natively using the GitHub CLI:
+```bash
+gh attestation verify antigravity-termux-standalone.tar.gz -R {{REPO}}
+```

--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+manifest_url="${MANIFEST_URL:-https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json}"
+
+if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+  echo "GITHUB_OUTPUT is required." >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "GITHUB_REPOSITORY is required." >&2
+  exit 1
+fi
+
+if [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GH_TOKEN or GITHUB_TOKEN is required for GitHub CLI authentication." >&2
+  exit 1
+fi
+
+echo "Querying official manifest..."
+manifest_json="$(curl -fsSL "$manifest_url")"
+manifest_fields="$(
+  jq -er '
+    .version as $version
+    | .url as $url
+    | select(
+        ($version | type) == "string" and ($version | length) > 0 and
+        ($url | type) == "string" and ($url | length) > 0
+      )
+    | $version, $url
+  ' <<<"$manifest_json"
+)"
+mapfile -t manifest <<<"$manifest_fields"
+
+if [[ ${#manifest[@]} -lt 2 ]]; then
+  echo "Error: Incomplete manifest data (expected version and download URL)." >&2
+  exit 1
+fi
+
+latest_official="${manifest[0]:-}"
+download_url="${manifest[1]:-}"
+release_tag="v${latest_official}"
+
+echo "Reading repository release tag from Actions Toolbox environment..."
+latest_release="${GH_LATEST_RELEASE_TAG:-}"
+
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+  echo "Dry run enabled! Overriding latest tag to v0.0.0 and forcing build execution."
+  latest_release="v0.0.0"
+fi
+
+latest_release="${latest_release#v}"
+
+if [[ -z "$latest_release" ]]; then
+  latest_release="0.0.0"
+fi
+
+echo "Official Latest Version  : $latest_official"
+echo "Your Latest Release Tag  : v$latest_release"
+
+if [[ "${DRY_RUN:-}" != "true" ]] && gh release view "$release_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+  echo "Release $release_tag already exists."
+  printf 'build_needed=false\n' >>"$GITHUB_OUTPUT"
+  exit 0
+fi
+
+echo "New version detected! Preparing automated build for $release_tag..."
+{
+  printf 'build_needed=true\n'
+  printf 'version=%s\n' "$latest_official"
+  printf 'url=%s\n' "$download_url"
+  printf 'latest_release=%s\n' "$latest_release"
+} >>"$GITHUB_OUTPUT"

--- a/.github/scripts/generate-release-notes.sh
+++ b/.github/scripts/generate-release-notes.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <target_version> [latest_release_version]" >&2
+  exit 1
+fi
+
+VERSION="${1#v}"
+
+if [[ "${DRY_RUN:-}" == "true" ]]; then
+  echo "Dry run enabled! Overriding latest tag to v0.0.0 for changelog compilation."
+  LATEST_RELEASE="0.0.0"
+elif [[ $# -ge 2 ]]; then
+  LATEST_RELEASE="${2#v}"
+else
+  latest_env="${GH_LATEST_RELEASE_TAG:-}"
+  LATEST_RELEASE="${latest_env#v}"
+fi
+
+LATEST_RELEASE="${LATEST_RELEASE:-0.0.0}"
+
+# Query fork commits since the last release tag
+echo "Extracting fork-specific release changelog..."
+FORK_CHANGELOG=""
+if [[ "$LATEST_RELEASE" != "0.0.0" ]] && git rev-parse "v$LATEST_RELEASE" >/dev/null 2>&1; then
+  FORK_CHANGELOG=$(git log "v$LATEST_RELEASE..HEAD" --oneline --pretty=format:"* %s (%h)")
+else
+  FORK_CHANGELOG=$(git log -n 20 --oneline --pretty=format:"* %s (%h)")
+fi
+
+if [[ -z "$FORK_CHANGELOG" ]]; then
+  FORK_CHANGELOG="* Maintenance rebuild / sync with upstream release."
+fi
+
+# Download the upstream changelog file
+mkdir -p staging
+echo "Downloading upstream CHANGELOG.md..."
+if ! curl -fsSL -o staging/CHANGELOG.md "https://raw.githubusercontent.com/google-antigravity/antigravity-cli/refs/heads/main/CHANGELOG.md"; then
+  echo "Warning: Failed to retrieve upstream CHANGELOG.md." >&2
+  rm -f staging/CHANGELOG.md
+fi
+
+# Extract the release notes section for the target version using mq
+echo "Extracting release notes for version ${VERSION} using mq..."
+UPSTREAM_NOTES=""
+if [[ -f "staging/CHANGELOG.md" ]]; then
+  UPSTREAM_NOTES=$(mq -A "import \"section\" | section::section(\"${VERSION}\")" staging/CHANGELOG.md 2>/dev/null || true)
+fi
+
+if [[ -z "${UPSTREAM_NOTES}" ]]; then
+  UPSTREAM_NOTES="Sync with upstream version v${VERSION}."
+fi
+
+escape_bash_replacement() {
+  local value="${1//\\/\\\\}"
+  printf '%s' "${value//&/\\&}"
+}
+
+# Render the final release notes from the template file
+REPO="${GITHUB_REPOSITORY:-wallentx/antigravity-cli-termux}"
+OWNER="${REPO%/*}"
+
+TEMPLATE_PATH=".github/release-template.md"
+if [[ -f "$TEMPLATE_PATH" ]]; then
+  # Append a dummy character to prevent command substitution from stripping trailing newlines
+  TEMPLATE=$(cat "$TEMPLATE_PATH"; printf 'x')
+  TEMPLATE="${TEMPLATE%x}"
+  
+  # Substitute placeholders with compiled values
+  VERSION_REPLACEMENT="$(escape_bash_replacement "$VERSION")"
+  FORK_CHANGELOG_REPLACEMENT="$(escape_bash_replacement "$FORK_CHANGELOG")"
+  UPSTREAM_NOTES_REPLACEMENT="$(escape_bash_replacement "$UPSTREAM_NOTES")"
+  REPO_REPLACEMENT="$(escape_bash_replacement "$REPO")"
+  OWNER_REPLACEMENT="$(escape_bash_replacement "$OWNER")"
+
+  OUTPUT="${TEMPLATE//\{\{VERSION\}\}/$VERSION_REPLACEMENT}"
+  OUTPUT="${OUTPUT//\{\{FORK_CHANGELOG\}\}/$FORK_CHANGELOG_REPLACEMENT}"
+  OUTPUT="${OUTPUT//\{\{UPSTREAM_NOTES\}\}/$UPSTREAM_NOTES_REPLACEMENT}"
+  OUTPUT="${OUTPUT//\{\{REPO\}\}/$REPO_REPLACEMENT}"
+  OUTPUT="${OUTPUT//\{\{OWNER\}\}/$OWNER_REPLACEMENT}"
+  
+  echo "$OUTPUT" > staging/release-notes.md
+  echo "Release notes generated successfully in staging/release-notes.md."
+else
+  echo "Error: Release template file not found at $TEMPLATE_PATH" >&2
+  exit 1
+fi

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,28 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color

--- a/.github/workflows/auto-sync-release.yml
+++ b/.github/workflows/auto-sync-release.yml
@@ -4,232 +4,89 @@ on:
   schedule:
     # Check for updates every 6 hours
     - cron: '0 */6 * * *'
-  workflow_dispatch: # Allows manual trigger from the Actions tab
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry Run (skip attestation and release creation)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   check-and-build:
     runs-on: ubuntu-latest
-    
-    # Required permissions for secure OIDC attestations and GH releases
+
+    env:
+      DRY_RUN: ${{ inputs.dry_run }}
+
+    defaults:
+      run:
+        shell: bash
+
     permissions:
-      id-token: write        # Required to authenticate with Sigstore OIDC
-      attestations: write    # Required to write build attestations
-      contents: write        # Required to write and publish releases
+      id-token: write
+      attestations: write
+      contents: write
+      actions: read
+      checks: read
+      deployments: read
+      issues: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      statuses: read
 
     steps:
-      # 1. Unshallow checkout to preserve history and tags for changelog generation
       - name: Checkout Code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Fetches all history and tags
+          fetch-depth: 0
 
-      # 2. Integrate custom composite diagnostics toolbox
       - name: 🧰 Actions Toolbox
         uses: wallentx/gh-actions/composite/actions-toolbox@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          checkout: false
 
-      # 3. Query versions and compare for difference
       - name: Check for New Version
         id: check_version
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          MANIFEST_URL: https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json
         run: |
-          echo "Querying official manifest..."
-          MANIFEST_JSON=$(curl -fsSL https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json)
-          LATEST_OFFICIAL=$(echo "$MANIFEST_JSON" | jq -r .version)
-          DOWNLOAD_URL=$(echo "$MANIFEST_JSON" | jq -r .url)
-          
-          echo "Querying repository releases via GitHub CLI..."
-          LATEST_RELEASE=$(gh release view --json tagName --template '{{.tagName}}' 2>/dev/null | sed 's/^v//' || echo "0.0.0")
-          
-          if [ -z "$LATEST_RELEASE" ]; then
-            LATEST_RELEASE="0.0.0"
-          fi
-          
-          echo "Official Latest Version  : $LATEST_OFFICIAL"
-          echo "Your Latest Release Tag  : v$LATEST_RELEASE"
-          
-          # Fetch all local tags to guarantee references exist in the workspace
-          git fetch --tags --force
-          
-          # Extract commit logs since the last release tag
-          echo "Generating fork-specific release changelog..."
-          FORK_CHANGELOG=""
-          if [ "$LATEST_RELEASE" != "0.0.0" ] && git rev-parse "v$LATEST_RELEASE" >/dev/null 2>&1; then
-            FORK_CHANGELOG=$(git log "v$LATEST_RELEASE..HEAD" --oneline --pretty=format:"* %s (%h)")
-          else
-            FORK_CHANGELOG=$(git log -n 20 --oneline --pretty=format:"* %s (%h)")
-          fi
-          
-          if [ -z "$FORK_CHANGELOG" ]; then
-            FORK_CHANGELOG="* Maintenance rebuild / sync with upstream release."
-          fi
-          
-          mkdir -p staging
-          echo "$FORK_CHANGELOG" > staging/fork-changelog.md
-          
-          if [ "$LATEST_OFFICIAL" != "$LATEST_RELEASE" ]; then
-            echo "New version detected! Preparing automated build for v$LATEST_OFFICIAL..."
-            {
-              echo "build_needed=true"
-              echo "version=$LATEST_OFFICIAL"
-              echo "url=$DOWNLOAD_URL"
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "build_needed=false" >> "$GITHUB_OUTPUT"
-          fi
+          ./.github/scripts/check-version.sh
 
-      # 4. Download latest upstream dynamic binary
-      - name: Fetch Upstream Antigravity CLI
+      - name: Build Standalone Binaries
         if: steps.check_version.outputs.build_needed == 'true'
         run: |
-          mkdir -p staging bin lib
-          curl -fsSL -o staging/agy.tar.gz "${{ steps.check_version.outputs.url }}"
-          tar -xzf staging/agy.tar.gz -C staging/
+          ./build.sh
 
-      # 5. Apply VA39 structural memory allocations patch
-      - name: Apply VA39 Memory Patches
-        if: steps.check_version.outputs.build_needed == 'true'
-        run: |
-          python3 - staging/antigravity bin/agy.va39 <<'PY'
-          import hashlib, shutil, struct, sys, pathlib
-          src = pathlib.Path("staging/antigravity")
-          dst = pathlib.Path("bin/agy.va39")
-          shutil.copyfile(src, dst)
-          data = bytearray(dst.read_bytes())
-          def get(off): return struct.unpack_from("<I", data, off)[0]
-          def put(off, word): struct.pack_into("<I", data, off, word)
-          
-          lo, hi = 0, len(data)
-          ubfx_count = lsl_count = mask_count = mmap_count = faccessat2_count = 0
-          for off in range(lo, hi, 4):
-              w = get(off)
-              if (w & 0x7F800000) == 0x53000000:
-                  immr, imms = (w >> 16) & 0x3F, (w >> 10) & 0x3F
-                  if immr == 42 and imms == 44:
-                      put(off, (w & ~((0x3F << 16) | (0x3F << 10))) | (35 << 16) | (37 << 10)); ubfx_count += 1
-                  elif immr == 22 and imms == 21:
-                      put(off, (w & ~((0x3F << 16) | (0x3F << 10))) | (29 << 16) | (28 << 10)); lsl_count += 1
-          for off in range(lo, hi - 4, 4):
-              if get(off) == 0x92D3800A and get(off + 4) == 0xF2E0000A:
-                  put(off, 0x9280000A); put(off + 4, 0xD35DFD4A); mask_count += 1
-          for off in range(lo, hi, 4):
-              if get(off) == 0xF2E00029: put(off, 0xD3596129); mmap_count += 1
-          word_rewrites = {
-              0xD2C20009: 0xD2C00409, 0xD2C2000A: 0xD2C0040A, 0xF2C20008: 0xF2DFF408,
-              0xF2C20009: 0xF2DFF409, 0xD2C10009: 0xD2C00209, 0xD2C1000A: 0xD2C0020A,
-              0xF2C38008: 0xF2DFF708, 0xF2C38009: 0xF2DFF709, 0x92560A6C: 0x925D0A6C,
-              0x92560A6A: 0x925D0A6A, 0xD2C3000D: 0xD2C0060D, 0xD2C3000C: 0xD2C0060C,
-              0xD2C08008: 0xD2C00108,
-          }
-          for off in range(lo, hi, 4):
-              w = get(off)
-              if w in word_rewrites: put(off, word_rewrites[w])
-          for off in range(0, len(data) - 12, 4):
-              if get(off) == 0xAA1F03E5 and get(off + 4) == 0xAA1F03E6 and get(off + 8) == 0xD28036E0 and (get(off + 12) & 0xFC000000) == 0x94000000:
-                  put(off + 8, 0xD2800600); faccessat2_count += 1
-          dst.write_bytes(data)
-          dst.chmod(0o755)
-          print("Patched VA39 structural memory parameters successfully.")
-          PY
-
-      # 6. Cross-Compile Bionic C Bootstrapper targeting aarch64 Android
-      - name: Cross-Compile Bionic C Bootstrapper (aarch64)
-        if: steps.check_version.outputs.build_needed == 'true'
-        run: |
-          NDK_CC="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
-          $NDK_CC -O2 -o bin/agy lib/agy_helper.c
-
-      # 7. Compress relocatable output files
       - name: Package Standalone Archive
         if: steps.check_version.outputs.build_needed == 'true'
         run: |
           tar -czf antigravity-termux-standalone.tar.gz bin/
 
-      # 8. Cryptographically sign build provenance via Sigstore
       - name: Attest Artifacts
         uses: actions/attest-build-provenance@v4
-        if: steps.check_version.outputs.build_needed == 'true'
+        if: steps.check_version.outputs.build_needed == 'true' && inputs.dry_run != true
         with:
           subject-path: 'antigravity-termux-standalone.tar.gz'
 
-      # 9. Fetch, parse, and merge changelogs (upstream + fork commits)
+      - name: Set up mq
+        if: steps.check_version.outputs.build_needed == 'true'
+        uses: harehare/setup-mq@v1
+
       - name: Fetch and Parse Release Notes
         if: steps.check_version.outputs.build_needed == 'true'
         run: |
-          VERSION="${{ steps.check_version.outputs.version }}"
-          echo "Downloading upstream CHANGELOG.md..."
-          curl -fsSL -o staging/CHANGELOG.md "https://raw.githubusercontent.com/wallentx/antigravity-cli-termux/refs/heads/main/CHANGELOG.md"
-          
-          echo "Parsing changelog notes for version $VERSION..."
-          python3 - "$VERSION" <<'PY'
-          import sys
-          from pathlib import Path
-          
-          version = sys.argv[1]
-          changelog_path = Path("staging/CHANGELOG.md")
-          fork_changelog_path = Path("staging/fork-changelog.md")
-          
-          # Fetch fork specific changes if available
-          fork_notes = fork_changelog_path.read_text().strip() if fork_changelog_path.exists() else "* Maintenance rebuild / sync."
-          
-          # Fetch upstream changes
-          if not changelog_path.exists():
-              notes_text = f"Sync with upstream version v{version}."
-          else:
-              content = changelog_path.read_text()
-              start_tag = f"## {version}"
-              if start_tag not in content:
-                  notes_text = f"Sync with upstream version v{version}."
-              else:
-                  lines = content.splitlines()
-                  release_notes = []
-                  started = False
-                  for line in lines:
-                      if line.startswith(start_tag):
-                          started = True
-                          continue
-                      if started:
-                          if line.startswith("## "):
-                              break
-                          release_notes.append(line)
-                  notes_text = "\n".join(release_notes).strip()
-          
-          if not notes_text:
-              notes_text = f"Sync with upstream version v{version}."
-              
-          full_notes = (
-              f"Automated standalone Termux build of the Antigravity CLI v{version}.\n\n"
-              f"> [!IMPORTANT]\n"
-              f"> **Twin-Binary Requirement:** The release package contains **two** binaries: `bin/agy` and `bin/agy.va39`.\n"
-              f"> * `bin/agy.va39` is the core patched engine.\n"
-              f"> * `bin/agy` is the native Bionic C bootstrapper.\n"
-              f"> **Always execute the `./bin/agy` binary.** It automatically clears conflicts and executes the core engine. You **must** keep both files in the same directory for the bootstrapper to run successfully.\n\n"
-              f"### 🔀 Standalone Fork Changelog\n"
-              f"{fork_notes}\n\n"
-              f"### ⬆️ Upstream Changelog (v{version})\n\n{notes_text}\n\n"
-              f"### 📦 Installation\n"
-              f"To install this release, extract the package to your preferred location (e.g. `~/.local` or a sandbox folder) and execute the C helper directly:\n"
-              f"```bash\n"
-              f"# 1. Download and extract\n"
-              f"curl -fsSLO https://github.com/${{ github.repository }}/releases/download/v{version}/antigravity-termux-standalone.tar.gz\n"
-              f"tar -xzf antigravity-termux-standalone.tar.gz\n\n"
-              f"# 2. Run immediately without shell configuration or wrappers!\n"
-              f"./bin/agy --help\n"
-              f"```\n\n"
-              f"### 🔒 Cryptographic Verification\n"
-              f"This release is signed with cryptographic build provenance. Verify it natively using the GitHub CLI:\n"
-              f"```bash\n"
-              f"gh attestation verify antigravity-termux-standalone.tar.gz --owner ${{ github.repository_owner }}\n"
-              f"```"
-          )
-          
-          Path("staging/release-notes.md").write_text(full_notes)
-          print("Release notes generated successfully.")
-          PY
+          ./.github/scripts/generate-release-notes.sh \
+            "${{ steps.check_version.outputs.version }}"
 
-      # 10. Create Release and Upload Asset natively using GitHub CLI
       - name: Create and Publish GitHub Release
-        if: steps.check_version.outputs.build_needed == 'true'
+        if: steps.check_version.outputs.build_needed == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/auto-sync-release.yml
+++ b/.github/workflows/auto-sync-release.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           subject-path: 'antigravity-termux-standalone.tar.gz'
 
-      # 10. Fetch, parse, and merge changelogs (upstream + fork commits)
+      # 9. Fetch, parse, and merge changelogs (upstream + fork commits)
       - name: Fetch and Parse Release Notes
         if: steps.check_version.outputs.build_needed == 'true'
         run: |
@@ -227,7 +227,7 @@ jobs:
           print("Release notes generated successfully.")
           PY
 
-      # 11. Create Release and Upload Asset natively using GitHub CLI
+      # 10. Create Release and Upload Asset natively using GitHub CLI
       - name: Create and Publish GitHub Release
         if: steps.check_version.outputs.build_needed == 'true'
         env:

--- a/.github/workflows/auto-sync-release.yml
+++ b/.github/workflows/auto-sync-release.yml
@@ -139,20 +139,13 @@ jobs:
           NDK_CC="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang"
           $NDK_CC -O2 -o bin/agy lib/agy_helper.c
 
-      # 7. Stage local glibc runtime symlinks
-      - name: Stage Runtime Library Symlinks
-        if: steps.check_version.outputs.build_needed == 'true'
-        run: |
-          ln -sfn /data/data/com.termux/files/usr/glibc/lib/libc.so.6 lib/libc.so
-          ln -sfn /data/data/com.termux/files/usr/glibc/lib/libc.so.6 lib/libc.so.6
-
-      # 8. Compress relocatable output files
+      # 7. Compress relocatable output files
       - name: Package Standalone Archive
         if: steps.check_version.outputs.build_needed == 'true'
         run: |
-          tar -czf antigravity-termux-standalone.tar.gz bin/ lib/
+          tar -czf antigravity-termux-standalone.tar.gz bin/
 
-      # 9. Cryptographically sign build provenance via Sigstore
+      # 8. Cryptographically sign build provenance via Sigstore
       - name: Attest Artifacts
         uses: actions/attest-build-provenance@v4
         if: steps.check_version.outputs.build_needed == 'true'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,27 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    paths:
+      - '**/*.sh'
+      - '.github/scripts/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shellcheck-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run ShellCheck
+        uses: bewuethr/shellcheck-action@v2.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Build Outputs & Temporary Files
+bin/*
+staging/
+*.tar.gz
+
+# Local Application Settings & Sandboxes
+.antigravitycli/
+.scratch/
+
+# Local Editor Configurations
+.cursorrules
+
+# System Artifacts
+.DS_Store
+Thumbs.db
+
+# Python Cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Antigravity CLI Termux Standalone Binary Builder
+# Fetches/compiles the C bootstrapper and applies VA39 memory patches.
+set -Eeuo pipefail
+
+# Enforce execution from the script's directory root
+cd "$(dirname "$0")"
+
+# Configuration and defaults
+MANIFEST_URL="https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_arm64.json"
+
+# Color definitions
+if [[ -t 1 ]]; then
+  DIM="\033[2m"
+  GREEN="\033[32m"
+  RED="\033[31m"
+  CYAN="\033[36m"
+  RESET="\033[0m"
+else
+  DIM="" GREEN="" RED="" CYAN="" RESET=""
+fi
+
+# Logging helpers
+info()    { printf '%b\n' " ${CYAN}[..]${RESET} ${DIM}$*${RESET}"; }
+ok()      { printf '%b\n' " ${GREEN}[OK]${RESET} $*"; }
+error()   { printf '%b\n' " ${RED}[ERR]${RESET} $*" >&2; }
+die()     { error "$*"; exit 1; }
+
+# Help and usage
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") [path_to_upstream_antigravity]
+
+Compiles the native C bootstrapper and applies VA39 memory patches.
+
+Arguments:
+  [path_to_upstream_antigravity]   Optional. Path to a local raw arm64 binary.
+                                   If omitted, fetches the latest upstream binary automatically.
+
+Requirements:
+  - curl, jq, tar, python3
+  - clang or gcc (or \$ANDROID_NDK_HOME configured for cross-compiling)
+EOF
+}
+
+# Check for help flag
+if [[ "${1:-}" = "-h" || "${1:-}" = "--help" ]]; then
+  show_help
+  exit 0
+fi
+
+# Cleanup Hook
+cleanup() {
+  if [[ -d "staging" ]]; then
+    info "Cleaning up staging directory..."
+    rm -rf staging
+  fi
+}
+trap cleanup EXIT
+
+# Prerequisite checks
+check_prereqs() {
+  info "Checking build prerequisites..."
+  local missing=()
+  for cmd in curl jq tar python3; do
+    if ! command -v "$cmd" &>/dev/null; then
+      missing+=("$cmd")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    die "Missing required command-line utilities: ${missing[*]}"
+  fi
+}
+
+# Compiler detection
+detect_compiler() {
+  if [[ -n "${ANDROID_NDK_HOME:-}" ]]; then
+    local ndk_clang
+    ndk_clang=$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -name "aarch64-linux-android*-clang" -print -quit 2>/dev/null)
+    if [[ -n "$ndk_clang" && -x "$ndk_clang" ]]; then
+      echo "$ndk_clang"
+      return 0
+    fi
+  fi
+
+  if [[ -x "/data/data/com.termux/files/usr/bin/clang" ]]; then
+    echo "/data/data/com.termux/files/usr/bin/clang"
+    return 0
+  fi
+
+  if command -v clang &>/dev/null; then
+    echo "clang"
+    return 0
+  elif command -v gcc &>/dev/null; then
+    echo "gcc"
+    return 0
+  fi
+
+  return 1
+}
+
+# Main builder logic
+check_prereqs
+
+# Detect C compiler
+local_cc=""
+if ! local_cc=$(detect_compiler); then
+  die "No suitable C compiler found (clang/gcc or ANDROID_NDK_HOME not configured)."
+fi
+info "Selected C compiler: $local_cc"
+
+# Create directories
+mkdir -p staging bin
+
+UPSTREAM_BIN=""
+
+if [[ $# -gt 0 ]]; then
+  UPSTREAM_BIN="$1"
+  if [[ ! -f "$UPSTREAM_BIN" ]]; then
+    die "Specified upstream binary not found: $UPSTREAM_BIN"
+  fi
+  info "Using local upstream binary: $UPSTREAM_BIN"
+else
+  info "Querying latest official version..."
+  manifest=$(curl -fsSL "$MANIFEST_URL")
+  if [[ -z "$manifest" ]]; then
+    die "Failed to query manifest from $MANIFEST_URL"
+  fi
+  
+  latest_version=$(echo "$manifest" | jq -r .version)
+  download_url=$(echo "$manifest" | jq -r .url)
+  
+  info "Latest official version found: v$latest_version"
+  info "Downloading upstream dynamic binary..."
+  if ! curl -fsSL -o staging/agy.tar.gz "$download_url"; then
+    die "Failed to download upstream binary from $download_url"
+  fi
+  
+  info "Extracting upstream dynamic binary..."
+  if ! tar -xzf staging/agy.tar.gz -C staging/; then
+    die "Failed to extract upstream binary."
+  fi
+  
+  if [[ -f "staging/antigravity" ]]; then
+    UPSTREAM_BIN="staging/antigravity"
+  elif [[ -f "staging/agy" ]]; then
+    UPSTREAM_BIN="staging/agy"
+  else
+    die "Could not find extracted binary in staging/"
+  fi
+fi
+
+# 1. Apply VA39 Memory Patches to generate bin/agy.va39
+info "Applying VA39 structural memory allocation patches..."
+python3 - "$UPSTREAM_BIN" "bin/agy.va39" <<'PY'
+import sys, shutil, struct, pathlib
+src = pathlib.Path(sys.argv[1])
+dst = pathlib.Path(sys.argv[2])
+shutil.copyfile(src, dst)
+data = bytearray(dst.read_bytes())
+def get(off): return struct.unpack_from("<I", data, off)[0]
+def put(off, word): struct.pack_into("<I", data, off, word)
+
+lo, hi = 0, len(data)
+ubfx_count = lsl_count = mask_count = mmap_count = faccessat2_count = 0
+for off in range(lo, hi, 4):
+    w = get(off)
+    if (w & 0x7F800000) == 0x53000000:
+        immr, imms = (w >> 16) & 0x3F, (w >> 10) & 0x3F
+        if immr == 42 and imms == 44:
+            put(off, (w & ~((0x3F << 16) | (0x3F << 10))) | (35 << 16) | (37 << 10)); ubfx_count += 1
+        elif immr == 22 and imms == 21:
+            put(off, (w & ~((0x3F << 16) | (0x3F << 10))) | (29 << 16) | (28 << 10)); lsl_count += 1
+for off in range(lo, hi - 4, 4):
+    if get(off) == 0x92D3800A and get(off + 4) == 0xF2E0000A:
+        put(off, 0x9280000A); put(off + 4, 0xD35DFD4A); mask_count += 1
+for off in range(lo, hi, 4):
+    if get(off) == 0xF2E00029: put(off, 0xD3596129); mmap_count += 1
+word_rewrites = {
+    0xD2C20009: 0xD2C00409, 0xD2C2000A: 0xD2C0040A, 0xF2C20008: 0xF2DFF408,
+    0xF2C20009: 0xF2DFF409, 0xD2C10009: 0xD2C00209, 0xD2C1000A: 0xD2C0020A,
+    0xF2C38008: 0xF2DFF708, 0xF2C38009: 0xF2DFF709, 0x92560A6C: 0x925D0A6C,
+    0x92560A6A: 0x925D0A6A, 0xD2C3000D: 0xD2C0060D, 0xD2C3000C: 0xD2C0060C,
+    0xD2C08008: 0xD2C00108,
+}
+for off in range(lo, hi, 4):
+    w = get(off)
+    if w in word_rewrites: put(off, word_rewrites[w])
+for off in range(0, len(data) - 12, 4):
+    if get(off) == 0xAA1F03E5 and get(off + 4) == 0xAA1F03E6 and get(off + 8) == 0xD28036E0 and (get(off + 12) & 0xFC000000) == 0x94000000:
+        put(off + 8, 0xD2800600); faccessat2_count += 1
+dst.write_bytes(data)
+dst.chmod(0o755)
+print(f"Patched parameters: ubfx={ubfx_count}, lsl={lsl_count}, mask={mask_count}, mmap={mmap_count}, faccessat2={faccessat2_count}")
+PY
+ok "Patched binary generated: bin/agy.va39"
+
+# 2. Compile native C bootstrapper bin/agy
+info "Compiling native C bootstrapper from lib/agy_helper.c..."
+if ! "$local_cc" -O2 -o bin/agy lib/agy_helper.c; then
+  die "Compilation of lib/agy_helper.c failed."
+fi
+chmod +x bin/agy
+ok "Native bootstrapper compiled: bin/agy"

--- a/install.sh
+++ b/install.sh
@@ -44,12 +44,10 @@ if [[ -t 1 ]]; then
   DIM="\033[2m"
   GREEN="\033[32m"
   RED="\033[31m"
-  YELLOW="\033[33m"
   CYAN="\033[36m"
-  MAGENTA="\033[35m"
   RESET="\033[0m"
 else
-  BOLD="" DIM="" GREEN="" RED="" YELLOW="" CYAN="" MAGENTA="" RESET=""
+  BOLD="" DIM="" GREEN="" RED="" CYAN="" RESET=""
 fi
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -64,7 +62,7 @@ die() {
       printf '\n%b\n' " ${RED}[ERR]${RESET} Installation failed or was cancelled."
     fi
     printf "For manual patching and installation:\n"
-    printf "${CYAN}https://gist.github.com/Brajesh2022/e42160d29b55417db6c18c52dd1d6d37${RESET}\n\n"
+    printf "%bhttps://gist.github.com/Brajesh2022/e42160d29b55417db6c18c52dd1d6d37%b\n\n" "$CYAN" "$RESET"
   } >&2
   exit 1
 }
@@ -77,16 +75,16 @@ spinner() {
   printf "\033[?25l" # Hide cursor
   while kill -0 "$pid" 2>/dev/null; do
     local temp=${spinstr#?}
-    printf "\r\033[K ${CYAN}[%c]${RESET} ${DIM}%s${RESET}" "$spinstr" "$msg"
+    printf "\r\033[K %b[%c]%b %b%s%b" "$CYAN" "$spinstr" "$RESET" "$DIM" "$msg" "$RESET"
     local spinstr=$temp${spinstr%"$temp"}
     sleep 0.1
   done
   local exit_status=0
   wait "$pid" || exit_status=$?
   if [ $exit_status -eq 0 ]; then
-    printf "\r\033[K ${GREEN}[OK]${RESET} %s\n" "$msg"
+    printf "\r\033[K %b[OK]%b %s\n" "$GREEN" "$RESET" "$msg"
   else
-    printf "\r\033[K ${RED}[ERR]${RESET} %s\n" "$msg"
+    printf "\r\033[K %b[ERR]%b %s\n" "$RED" "$RESET" "$msg"
   fi
   printf "\033[?25h" # Show cursor
   return $exit_status
@@ -104,16 +102,16 @@ progress_spinner() {
     if [[ -f "$pct_file" ]]; then
       pct=$(tail -n 1 "$pct_file" 2>/dev/null || echo "  0")
     fi
-    printf "\r\033[K ${CYAN}[%c]${RESET} [%3d%%] ${DIM}%s${RESET}" "$spinstr" "$pct" "$msg"
+    printf "\r\033[K %b[%c]%b [%3s%%] %b%s%b" "$CYAN" "$spinstr" "$RESET" "$pct" "$DIM" "$msg" "$RESET"
     local spinstr=$temp${spinstr%"$temp"}
     sleep 0.1
   done
   local exit_status=0
   wait "$pid" || exit_status=$?
   if [ $exit_status -eq 0 ]; then
-    printf "\r\033[K ${GREEN}[OK]${RESET} %s\n" "$msg"
+    printf "\r\033[K %b[OK]%b %s\n" "$GREEN" "$RESET" "$msg"
   else
-    printf "\r\033[K ${RED}[ERR]${RESET} %s\n" "$msg"
+    printf "\r\033[K %b[ERR]%b %s\n" "$RED" "$RESET" "$msg"
   fi
   printf "\033[?25h" # Restore cursor
   return $exit_status
@@ -183,7 +181,7 @@ download_with_progress() {
       printf "\r\033[K %s[OK]%s [%s] 100%% %s%5.1fM / %4.1fM%s\n", grn, rst, bar, dim, t_mb, t_mb, rst
     }'
   else
-    printf "\r\033[K ${RED}[ERR]${RESET} Download failed.\n"
+    printf "\r\033[K %b[ERR]%b Download failed.\n" "$RED" "$RESET"
   fi
   
   printf "\033[?25h" # Restore cursor


### PR DESCRIPTION
This refactors the automated Termux release workflow so the release artifact only packages the standalone runtime binaries and the CI logic is easier to maintain.

Changes include:

- Removes staged glibc runtime symlinks from the standalone archive; releases now package `bin/` only.
- Moves version detection into `.github/scripts/check-version.sh`.
- Moves release-note generation into `.github/scripts/generate-release-notes.sh`.
- Adds `.github/release-template.md` for release body rendering.
- Adds a manual `dry_run` workflow input that exercises the build path while skipping attestation and release publishing.
- Uses `mq` to extract upstream changelog sections.
- Adds ShellCheck, actionlint, and Dependabot coverage for workflow/script maintenance.
- Adds `.gitignore` entries for build outputs and local scratch files.

## Notes

The standalone release package still expects the twin-binary layout:

- `bin/agy`
- `bin/agy.va39`

The release artifact no longer includes `lib/`, since those glibc symlinks are not needed for runtime execution of the packaged `agy` helper.