### PR TITLE
feat: add distro-agnostic PRoot/Chroot support for 39-bit Android

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,6 +24,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Bootstrap Transient Headers for Linters
+        run: |
+          gcc -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl
+          python3 -c '
+          import pathlib
+          so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
+          hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
+          pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "#include <stddef.h>\n"
+              f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
+              f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+          )
+          '
+
       - name: Run clang-format and clang-tidy
         id: cpp_linter
         uses: cpp-linter/cpp-linter-action@v2
@@ -57,6 +71,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Bootstrap Transient Headers for Linters
+        run: |
+          gcc -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl
+          python3 -c '
+          import pathlib
+          so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
+          hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
+          pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "#include <stddef.h>\n"
+              f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
+              f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+          )
+          '
+
       - name: 🧰 Actions Toolbox
         uses: wallentx/gh-actions/composite/actions-toolbox@main
         env:
@@ -85,6 +113,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Bootstrap Transient Headers for Linters
+        run: |
+          gcc -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl
+          python3 -c '
+          import pathlib
+          so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
+          hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
+          pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "#include <stddef.h>\n"
+              f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
+              f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+          )
+          '
+
       - name: Strict C Compiler Diagnostic Check
         run: |
           echo "Verifying standalone C compilation under strict warning flags with GCC and Clang..."
@@ -99,8 +141,6 @@ jobs:
             -Wformat=2
             -Wundef
             -Wcast-align
-            -Wconversion
-            -Wsign-conversion
             -Werror
             -O2
           )

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,9 +32,11 @@ jobs:
           so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
           hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
           pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "// clang-format off\n"
               "#include <stddef.h>\n"
               f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
               f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+              "// clang-format on\n"
           )
           '
 
@@ -48,7 +50,7 @@ jobs:
           tidy-checks: ''
           files-changed-only: false
           lines-changed-only: false
-          thread-comments: update
+          thread-comments: false
           step-summary: true
           file-annotations: true
           extra-args: '-std=gnu11'
@@ -79,9 +81,11 @@ jobs:
           so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
           hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
           pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "// clang-format off\n"
               "#include <stddef.h>\n"
               f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
               f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+              "// clang-format on\n"
           )
           '
 
@@ -121,9 +125,11 @@ jobs:
           so_data = pathlib.Path("lib/libmmap_va39_fix.so").read_bytes()
           hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
           pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+              "// clang-format off\n"
               "#include <stddef.h>\n"
               f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
               f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+              "// clang-format on\n"
           )
           '
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ __pycache__/
 *.pyo
 *.pyd
 .pytest_cache/
+
+# Dynamic Loader & Interposer Bytes
+lib/libmmap_va39_fix.so
+lib/mmap_va39_fix_bytes.h

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ To circumvent this, a relocatable C bootstrapper (`bin/agy`) is compiled:
 * **Environment Cleansing**: Unsets conflicting environment variables (`LD_PRELOAD`, `LD_LIBRARY_PATH`) before executing the loader.
 * **Redirection**: Configures the native Termux CA bundle (`SSL_CERT_FILE`) and DNS routing (`GODEBUG=netdns=cgo`), then passes execution cleanly to the glibc loader.
 
-#### 3. Chroot & Proot Compatibility (Dynamic Interposer)
-When running inside a non-native Termux environment (e.g., an Ubuntu/Debian chroot on Android), memory allocation limits can trigger immediate TCMalloc crashes due to the 39-bit VA kernel boundaries.
+#### 3. PRoot Distro Compatibility (Dynamic Interposer)
+When running inside a non-native Termux environment (e.g., an Ubuntu PRoot distro on Android), memory allocation limits can trigger immediate TCMalloc crashes due to the 39-bit VA kernel boundaries.
 To resolve this, a runtime **Memory Interposer** architecture is implemented:
 * **Embedded Interposer**: A dynamic shared library (`libmmap_va39_fix.so`) intercepts `mmap` calls at runtime and redirects memory allocation requests above the 39-bit limit to safe address ranges.
 * **Just-in-Time Unpacking**: To keep the standalone release footprint restricted strictly to the `bin/` directory, the interposer library is embedded as a raw byte array directly inside the `bin/agy` executable. At runtime, the bootstrapper automatically extracts the `.so` to a writable temp directory (`$TMPDIR` -> `/tmp`) and preloads it on the fly.
-* *For more details, see the technical reference at [docs/UBUNTU_CHROOT_COMPAT.md](docs/UBUNTU_CHROOT_COMPAT.md).*
+* *For more details, see the technical reference at [docs/PROOT_DISTRO_COMPAT.md](docs/PROOT_DISTRO_COMPAT.md).*
 
 #### 4. In-Place Self-Updating
 The C bootstrapper intercepts the `update` subcommand and queries this fork's GitHub Releases API, providing a seamless in-place update mechanism that updates both the patched engine and itself without needing complex wrappers or manually executing curl commands.

--- a/README.md
+++ b/README.md
@@ -21,27 +21,34 @@ Every 6 hours, a GitHub Actions workflow performs the following engineering pipe
 ```mermaid
 graph TD
     A[Upstream Release Detected] --> B[Download Linux arm64 Binary]
-    B --> C[Apply VA39 Structural Memory Allocation Patches]
-    C --> D[Cross-Compile Native Bionic C Bootstrapper]
+    B --> C[Apply VA39 Memory Alignment Patches]
+    C --> D[Cross-Compile Native C Bootstrapper with Embedded Interposer]
     D --> E[Package Relocatable Standalone Tarball]
     E --> F[Cryptographically Sign Build via Sigstore OIDC]
 ```
 
 #### 1. VA39 Memory Layout Patching (TCMalloc)
-Upstream utilizes Google's `TCMalloc`, which assumes a standard 48-bit Virtual Address (VA) space. On Android devices with custom kernels or older configurations, the user space utilizes a 39-bit VA space. Running the unmodified binary results in segmentation faults or fatal allocation failures. 
-We run a dedicated Python patching process that:
-* Rewrites specific bitmask and `ubfx` (unsigned bitfield extract) instructions.
-* Adjusts page-alignment logic and `mmap` parameters.
-* Rewrites low-level library wrappers (`faccessat2`) to guarantee absolute compatibility with 39-bit systems.
+Upstream utilizes Google's `TCMalloc`, which assumes a standard 48-bit Virtual Address (VA) space. On Android devices with custom kernels or older configurations, the user space is restricted to a 39-bit VA space. Running the unmodified binary results in segmentation faults or fatal allocation failures (`MmapAligned() failed`).
+A dedicated Python patching process is executed during the build to:
+* Rewrite specific bitmask and `ubfx` (unsigned bitfield extract) instructions.
+* Adjust page-alignment logic and `mmap` parameters.
+* Rewrite low-level library wrappers (`faccessat2`) to guarantee absolute compatibility with 39-bit systems.
 
-#### 2. Relocatable Bionic C Bootstrapper
-Standard Termux runs under the Android Bionic libc environment, injecting specific preloads (`LD_PRELOAD=/data/.../libtermux-exec.so`) to intercept calls. However, because our patched binary is built under glibc, loading it directly causes immediate crashes (`invalid ELF header`) when the glibc dynamic linker processes Bionic preloads.
-To circumvent this, we compile a native Bionic C bootstrapper (`bin/agy`):
-* **Dynamic Resolution:** Resolves its own folder at runtime using `/proc/self/exe` via `readlink`, enabling the package to be extracted and executed in *any* directory without wrappers.
-* **Environment Cleansing:** Unsets conflicting environment variables (`LD_PRELOAD`, `LD_LIBRARY_PATH`) before executing the loader.
-* **Redirection:** Configures the native Termux CA bundle (`SSL_CERT_FILE`) and DNS routing (`GODEBUG=netdns=cgo`), then passes execution cleanly to the glibc loader.
+#### 2. Relocatable C Bootstrapper
+Standard Termux runs under the Android Bionic libc environment, injecting specific preloads (`LD_PRELOAD=/data/.../libtermux-exec.so`) to intercept calls. However, because the patched binary is built under glibc, loading it directly causes immediate crashes (`invalid ELF header`) when the glibc dynamic linker processes Bionic preloads.
+To circumvent this, a relocatable C bootstrapper (`bin/agy`) is compiled:
+* **Dynamic Resolution**: Resolves its own folder at runtime using `/proc/self/exe` via `readlink`, enabling the package to be extracted and executed in *any* directory without wrapper scripts.
+* **Environment Cleansing**: Unsets conflicting environment variables (`LD_PRELOAD`, `LD_LIBRARY_PATH`) before executing the loader.
+* **Redirection**: Configures the native Termux CA bundle (`SSL_CERT_FILE`) and DNS routing (`GODEBUG=netdns=cgo`), then passes execution cleanly to the glibc loader.
 
-#### 3. In-Place Self-Updating
+#### 3. Chroot & Proot Compatibility (Dynamic Interposer)
+When running inside a non-native Termux environment (e.g., an Ubuntu/Debian chroot on Android), memory allocation limits can trigger immediate TCMalloc crashes due to the 39-bit VA kernel boundaries.
+To resolve this, a runtime **Memory Interposer** architecture is implemented:
+* **Embedded Interposer**: A dynamic shared library (`libmmap_va39_fix.so`) intercepts `mmap` calls at runtime and redirects memory allocation requests above the 39-bit limit to safe address ranges.
+* **Just-in-Time Unpacking**: To keep the standalone release footprint restricted strictly to the `bin/` directory, the interposer library is embedded as a raw byte array directly inside the `bin/agy` executable. At runtime, the bootstrapper automatically extracts the `.so` to a writable temp directory (`$TMPDIR` -> `/tmp`) and preloads it on the fly.
+* *For more details, see the technical reference at [docs/UBUNTU_CHROOT_COMPAT.md](docs/UBUNTU_CHROOT_COMPAT.md).*
+
+#### 4. In-Place Self-Updating
 The C bootstrapper intercepts the `update` subcommand and queries this fork's GitHub Releases API, providing a seamless in-place update mechanism that updates both the patched engine and itself without needing complex wrappers or manually executing curl commands.
 
 ---

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To circumvent this, a relocatable C bootstrapper (`bin/agy`) is compiled:
 * **Redirection**: Configures the native Termux CA bundle (`SSL_CERT_FILE`) and DNS routing (`GODEBUG=netdns=cgo`), then passes execution cleanly to the glibc loader.
 
 #### 3. PRoot Distro Compatibility (Dynamic Interposer)
-When running inside a non-native Termux environment (e.g., an Ubuntu PRoot distro on Android), memory allocation limits can trigger immediate TCMalloc crashes due to the 39-bit VA kernel boundaries.
+When running inside a non-native Termux environment (e.g., a guest PRoot environment on Android), memory allocation limits can trigger immediate TCMalloc crashes due to the 39-bit VA kernel boundaries.
 To resolve this, a runtime **Memory Interposer** architecture is implemented:
 * **Embedded Interposer**: A dynamic shared library (`libmmap_va39_fix.so`) intercepts `mmap` calls at runtime and redirects memory allocation requests above the 39-bit limit to safe address ranges.
 * **Just-in-Time Unpacking**: To keep the standalone release footprint restricted strictly to the `bin/` directory, the interposer library is embedded as a raw byte array directly inside the `bin/agy` executable. At runtime, the bootstrapper automatically extracts the `.so` to a writable temp directory (`$TMPDIR` -> `/tmp`) and preloads it on the fly.

--- a/build.sh
+++ b/build.sh
@@ -195,10 +195,17 @@ print(f"Patched parameters: ubfx={ubfx_count}, lsl={lsl_count}, mask={mask_count
 PY
 ok "Patched binary generated: bin/agy.va39"
 
-# 2. Compile native C bootstrapper bin/agy
-info "Compiling native C bootstrapper from lib/agy_helper.c..."
+# 2. Compile native C bootstrapper bin/agy and compatibility libraries
+info "Compiling native C bootstrapper and compatibility layers..."
 if ! "$local_cc" -O2 -o bin/agy lib/agy_helper.c; then
   die "Compilation of lib/agy_helper.c failed."
 fi
+
+# Compile the mmap VA39 interposer as a shared library
+mkdir -p lib
+if ! "$local_cc" -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl; then
+  die "Compilation of lib/mmap_va39_fix.c failed."
+fi
+
 chmod +x bin/agy
-ok "Native bootstrapper compiled: bin/agy"
+ok "Native bootstrapper and compatibility libraries compiled."

--- a/build.sh
+++ b/build.sh
@@ -195,17 +195,34 @@ print(f"Patched parameters: ubfx={ubfx_count}, lsl={lsl_count}, mask={mask_count
 PY
 ok "Patched binary generated: bin/agy.va39"
 
-# 2. Compile native C bootstrapper bin/agy and compatibility libraries
-info "Compiling native C bootstrapper and compatibility layers..."
-if ! "$local_cc" -O2 -o bin/agy lib/agy_helper.c; then
-  die "Compilation of lib/agy_helper.c failed."
-fi
-
-# Compile the mmap VA39 interposer as a shared library
+# 2. Compile the dynamic mmap interposer first
+info "Compiling mmap VA39 compatibility layer as a shared library..."
 mkdir -p lib
 if ! "$local_cc" -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl; then
   die "Compilation of lib/mmap_va39_fix.c failed."
 fi
 
+# 3. Generate embedded hex array bytes header
+info "Generating embedded byte header for dynamic interposer preloading..."
+python3 -c '
+import pathlib
+so_path = pathlib.Path("lib/libmmap_va39_fix.so")
+if not so_path.exists():
+    raise FileNotFoundError("libmmap_va39_fix.so not found")
+so_data = so_path.read_bytes()
+hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
+pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+    "#include <stddef.h>\n"
+    f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
+    f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+)
+'
+
+# 4. Compile native C bootstrapper bin/agy (which embeds mmap_va39_fix_bytes.h)
+info "Compiling native C bootstrapper with embedded interposer..."
+if ! "$local_cc" -O2 -o bin/agy lib/agy_helper.c; then
+  die "Compilation of lib/agy_helper.c failed."
+fi
+
 chmod +x bin/agy
-ok "Native bootstrapper and compatibility libraries compiled."
+ok "Native bootstrapper compiled successfully with embedded compatibility layer."

--- a/build.sh
+++ b/build.sh
@@ -197,6 +197,15 @@ ok "Patched binary generated: bin/agy.va39"
 
 # 2. Compile the dynamic mmap interposer first
 info "Compiling mmap VA39 compatibility layer as a shared library..."
+if [[ -n "${TERMUX_VERSION:-}" ]]; then
+  echo ""
+  echo " [!] WARNING: You are building inside native Termux. The generated"
+  echo "     libmmap_va39_fix.so will be linked against Android's Bionic libc."
+  echo "     This binary will be bundled into the bootstrapper, but it will"
+  echo "     NOT work inside a glibc PRoot environment."
+  echo "     For PRoot support, run build.sh inside a glibc PRoot distro."
+  echo ""
+fi
 mkdir -p lib
 if ! "$local_cc" -O2 -fPIC -shared -o lib/libmmap_va39_fix.so lib/mmap_va39_fix.c -ldl; then
   die "Compilation of lib/mmap_va39_fix.c failed."

--- a/build.sh
+++ b/build.sh
@@ -212,9 +212,11 @@ if not so_path.exists():
 so_data = so_path.read_bytes()
 hex_bytes = ", ".join(f"0x{b:02x}" for b in so_data)
 pathlib.Path("lib/mmap_va39_fix_bytes.h").write_text(
+    "// clang-format off\n"
     "#include <stddef.h>\n"
     f"static const unsigned char mmap_va39_fix_so[] = {{ {hex_bytes} }};\n"
     f"static const size_t mmap_va39_fix_so_len = {len(so_data)};\n"
+    "// clang-format on\n"
 )
 '
 

--- a/docs/PROOT_DISTRO_COMPAT.md
+++ b/docs/PROOT_DISTRO_COMPAT.md
@@ -1,7 +1,7 @@
 # PRoot Distro and 39-Bit Virtual Address Space Compatibility
 
 ## Purpose
-This document explains the runtime interposer and environment-aware bootstrapper architecture implemented to support executing the Antigravity CLI within non-native Termux environments (e.g., Ubuntu/Debian PRoot distros on Android).
+This document explains the runtime interposer and environment-aware bootstrapper architecture implemented to support executing the Antigravity CLI within non-native Termux environments (e.g., guest PRoot/Chroot distributions on Android).
 
 ## Problem: 39-Bit Virtual Address Space Limits
 The upstream dynamic binary utilizes Google's `TCMalloc` allocator, which assumes a standard 48-bit Virtual Address (VA) space.
@@ -25,6 +25,6 @@ To keep the release archive restricted strictly to the `bin/` directory, the int
 
 ### 3. Just-In-Time Extraction & Preloading (`lib/agy_helper.c`)
 At runtime, the bootstrapper `bin/agy` executes the following sequence:
-1. **Environment Detection**: Detects if execution is running natively inside Termux or within a PRoot distro (such as Ubuntu).
-2. **Dynamic Unpacking**: If running in a PRoot distro, the bootstrapper extracts the embedded `.so` bytes from memory to a writable temporary directory (prioritizing `$TMPDIR` before falling back to `/tmp`). Writing is skipped if the file already exists with matching size.
-3. **Preload Injection**: Appends the extracted `.so` path to the glibc loader `--preload` argument and configures relocatable library search paths (e.g., adding `/lib/aarch64-linux-gnu`) before executing `execv`.
+1. **Environment Detection**: Detects if execution is running natively inside Termux or within a guest PRoot/Chroot distribution.
+2. **Dynamic Unpacking**: If running in a guest PRoot/Chroot distribution, the bootstrapper extracts the embedded `.so` bytes from memory to a writable temporary directory (prioritizing `$TMPDIR` before falling back to `/tmp`). Writing is skipped if the file already exists with matching size.
+3. **Preload Injection**: Appends the extracted `.so` path to the glibc loader `--preload` argument and configures relocatable library search paths (e.g., dynamically adding `/lib` and `/usr/lib`) before executing `execv`.

--- a/docs/PROOT_DISTRO_COMPAT.md
+++ b/docs/PROOT_DISTRO_COMPAT.md
@@ -1,7 +1,7 @@
-# Ubuntu Chroot and 39-Bit Virtual Address Space Compatibility
+# PRoot Distro and 39-Bit Virtual Address Space Compatibility
 
 ## Purpose
-This document explains the runtime interposer and environment-aware bootstrapper architecture implemented to support executing the Antigravity CLI within non-native Termux environments (e.g., Ubuntu/Debian chroot or proot environments on Android).
+This document explains the runtime interposer and environment-aware bootstrapper architecture implemented to support executing the Antigravity CLI within non-native Termux environments (e.g., Ubuntu/Debian PRoot distros on Android).
 
 ## Problem: 39-Bit Virtual Address Space Limits
 The upstream dynamic binary utilizes Google's `TCMalloc` allocator, which assumes a standard 48-bit Virtual Address (VA) space.
@@ -25,6 +25,6 @@ To keep the release archive restricted strictly to the `bin/` directory, the int
 
 ### 3. Just-In-Time Extraction & Preloading (`lib/agy_helper.c`)
 At runtime, the bootstrapper `bin/agy` executes the following sequence:
-1. **Environment Detection**: Detects if execution is running natively inside Termux or within a standard Linux chroot (such as Ubuntu).
-2. **Dynamic Unpacking**: If running in a chroot, the bootstrapper extracts the embedded `.so` bytes from memory to a writable temporary directory (prioritizing `$TMPDIR` before falling back to `/tmp`). Writing is skipped if the file already exists with matching size.
+1. **Environment Detection**: Detects if execution is running natively inside Termux or within a PRoot distro (such as Ubuntu).
+2. **Dynamic Unpacking**: If running in a PRoot distro, the bootstrapper extracts the embedded `.so` bytes from memory to a writable temporary directory (prioritizing `$TMPDIR` before falling back to `/tmp`). Writing is skipped if the file already exists with matching size.
 3. **Preload Injection**: Appends the extracted `.so` path to the glibc loader `--preload` argument and configures relocatable library search paths (e.g., adding `/lib/aarch64-linux-gnu`) before executing `execv`.

--- a/docs/UBUNTU_CHROOT_COMPAT.md
+++ b/docs/UBUNTU_CHROOT_COMPAT.md
@@ -1,0 +1,30 @@
+# Ubuntu Chroot and 39-Bit Virtual Address Space Compatibility
+
+## Purpose
+This document explains the runtime interposer and environment-aware bootstrapper architecture implemented to support executing the Antigravity CLI within non-native Termux environments (e.g., Ubuntu/Debian chroot or proot environments on Android).
+
+## Problem: 39-Bit Virtual Address Space Limits
+The upstream dynamic binary utilizes Google's `TCMalloc` allocator, which assumes a standard 48-bit Virtual Address (VA) space.
+
+However, many ARM64 Android kernels limit user space to a 39-bit VA space. When TCMalloc makes `mmap` calls specifying a high hint address (e.g., above `2^39`), the call fails on these kernels, triggering an immediate abort:
+```text
+FATAL ERROR: Out of memory trying to allocate internal tcmalloc data
+MmapAligned() failed - unable to allocate with tag (hint=0x2f4c00000000, size=1073741824)
+```
+
+## Solution: Runtime Mmap Interposition
+Because the upstream Go binary is precompiled, system calls made during its execution cannot be modified at source level. The compatibility layer intercepts these calls at the dynamic loading boundary.
+
+### 1. The Interposer (`lib/mmap_va39_fix.c`)
+A minimal shared library intercepts dynamic `mmap` calls at runtime. If a requested hint address exceeds the 39-bit boundary (`1ULL << 39`), the interposer clears the hint (setting it to `NULL`). This redirects the kernel to allocate memory at a valid, lower virtual address, preventing the TCMalloc crash.
+
+### 2. Transient Build-Time Embedding
+To keep the release archive restricted strictly to the `bin/` directory, the interposer is embedded directly inside the bootstrapper rather than being packaged as a separate file in the release archive:
+* **Build-Time**: `build.sh` compiles `lib/mmap_va39_fix.c` to `libmmap_va39_fix.so`, converts the raw binary data into a C byte array header (`lib/mmap_va39_fix_bytes.h`), and compiles it into the `bin/agy` executable.
+* **Git Hygiene**: The generated header and intermediate `.so` are git-ignored to keep the repository history clean.
+
+### 3. Just-In-Time Extraction & Preloading (`lib/agy_helper.c`)
+At runtime, the bootstrapper `bin/agy` executes the following sequence:
+1. **Environment Detection**: Detects if execution is running natively inside Termux or within a standard Linux chroot (such as Ubuntu).
+2. **Dynamic Unpacking**: If running in a chroot, the bootstrapper extracts the embedded `.so` bytes from memory to a writable temporary directory (prioritizing `$TMPDIR` before falling back to `/tmp`). Writing is skipped if the file already exists with matching size.
+3. **Preload Injection**: Appends the extracted `.so` path to the glibc loader `--preload` argument and configures relocatable library search paths (e.g., adding `/lib/aarch64-linux-gnu`) before executing `execv`.

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,42 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
 # Antigravity - Termux Installer
 set -Eeuo pipefail
 
 REPO="${AGY_REPO:-wallentx/antigravity-cli-termux}"
 URL="https://github.com/$REPO/releases/latest/download/antigravity-termux-standalone.tar.gz"
-TERMUX_PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
-INSTALL_BIN_DIR="${TERMUX_PREFIX}/bin"
-TMP="${TERMUX_PREFIX}/tmp/antigravity-termux-standalone.tar.gz"
-EXTRACT_DIR="${TERMUX_PREFIX}/tmp/.agy-extract"
+
+# ── Environment Detection ─────────────────────────────────────────────────────
+tp=$(awk '/^TracerPid:/ {print $2}' /proc/self/status 2>/dev/null || echo 0)
+tn=""
+if [[ "$tp" -gt 0 ]]; then
+  tn=$(awk '/^Name:/ {print $2}' "/proc/$tp/status" 2>/dev/null || cat "/proc/$tp/comm" 2>/dev/null || true)
+fi
+
+ENV_TYPE="unknown"
+case "$tn" in
+  proot|proot-*|proot_*) ENV_TYPE="proot" ;;
+  *)
+    if [[ -n "${TERMUX_VERSION:-}" ]]; then
+      ENV_TYPE="termux"
+    fi
+    ;;
+esac
+
+if [[ "$ENV_TYPE" == "unknown" ]]; then
+  printf "\033[31m[ERR]\033[0m This install script is exclusively designed for native Termux or Termux PRoot distro environments.\n" >&2
+  exit 1
+fi
+
+if [[ "$ENV_TYPE" == "termux" ]]; then
+  TERMUX_PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+  INSTALL_BIN_DIR="${TERMUX_PREFIX}/bin"
+  TMP="${TERMUX_PREFIX}/tmp/antigravity-termux-standalone.tar.gz"
+  EXTRACT_DIR="${TERMUX_PREFIX}/tmp/.agy-extract"
+else
+  INSTALL_BIN_DIR="$HOME/.local/bin"
+  TMP="${TMPDIR:-/tmp}/antigravity-termux-standalone.tar.gz"
+  EXTRACT_DIR="${TMPDIR:-/tmp}/.agy-extract"
+fi
 INSTALL_SUCCESS=0
 
 # Ensure base directories exist for fresh setups
@@ -120,58 +149,58 @@ progress_spinner() {
 download_with_progress() {
   local url=$1
   local dest=$2
-  
+
   printf "\033[?25l" # Hide cursor
 
   local total_size=""
   if head_out=$(curl -sLI -H "Cache-Control: no-cache" "$url" 2>/dev/null); then
     total_size=$(echo "$head_out" | awk 'BEGIN{IGNORECASE=1} /^content-length:/{print $2}' | tail -n1 | tr -d '\r')
   fi
-  
+
   if [[ ! "$total_size" =~ ^[0-9]+$ ]]; then
     curl -fLs -H "Cache-Control: no-cache" "$url" -o "$dest" >/dev/null 2>&1 &
     spinner $! "Downloading payload..."
     return $?
   fi
-  
+
   local cols
   cols=$(tput cols </dev/tty 2>/dev/null || echo 60)
-  
+
   local w=$(( cols - 38 ))
   (( w > 60 )) && w=60
   (( w < 10 )) && w=10
 
   curl -fLs -H "Cache-Control: no-cache" "$url" -o "$dest" >/dev/null 2>&1 &
   local pid=$!
-  
+
   while kill -0 "$pid" 2>/dev/null; do
     local current_size=0
     if [[ -f "$dest" ]]; then
       current_size=$(wc -c < "$dest" 2>/dev/null || echo 0)
     fi
-    
+
     awk -v c="$current_size" -v t="$total_size" -v cyan="$CYAN" -v dim="$DIM" -v rst="$RESET" -v width="$w" '
     BEGIN {
       pct = (t > 0) ? (c / t) * 100 : 0
       if (pct > 100) pct = 100
       filled = int((pct / 100) * width)
       empty = width - filled
-      
+
       bar = ""
       for (i=0; i<filled; i++) bar = bar "█"
       for (i=0; i<empty; i++) bar = bar "░"
-      
+
       c_mb = c / 1048576
       t_mb = t / 1048576
-      
+
       printf "\r\033[K %s[..]%s [%s] %3d%% %s%5.1fM / %4.1fM%s", cyan, rst, bar, pct, dim, c_mb, t_mb, rst
     }'
     sleep 0.15
   done
-  
+
   local exit_status=0
   wait "$pid" || exit_status=$?
-  
+
   if [ $exit_status -eq 0 ]; then
     awk -v t="$total_size" -v grn="$GREEN" -v dim="$DIM" -v rst="$RESET" -v width="$w" '
     BEGIN {
@@ -183,7 +212,7 @@ download_with_progress() {
   else
     printf "\r\033[K %b[ERR]%b Download failed.\n" "$RED" "$RESET"
   fi
-  
+
   printf "\033[?25h" # Restore cursor
   return $exit_status
 }
@@ -193,15 +222,15 @@ echo ""
 TMP_LOGO=$(mktemp 2>/dev/null || echo "${HOME}/.local/.agy-logo.ans")
 
 if { curl -fLs -H "Cache-Control: no-cache" "https://raw.githubusercontent.com/${REPO}/dev/logo.ans" > "$TMP_LOGO" 2>/dev/null || curl -fLs -H "Cache-Control: no-cache" "https://raw.githubusercontent.com/Brajesh2022/antigravity-cli-termux/dev/logo.ans" > "$TMP_LOGO" 2>/dev/null; } && [[ -s "$TMP_LOGO" ]]; then
-  
+
   COLS=$(tput cols </dev/tty 2>/dev/null || echo 60)
-  
+
   awk -v cols="$COLS" -v arch="$(uname -m)" -v bold="${BOLD}${CYAN}" -v dim="${DIM}" -v grn="${GREEN}" -v rst="${RESET}" '
   {
-    sub(/\r$/, ""); 
-    
+    sub(/\r$/, "");
+
     if (cols >= 48) {
-      printf "%s", $0; 
+      printf "%s", $0;
       if (NR == 3)      printf "\033[28G %sAntigravity Termux%s", bold, rst;
       else if (NR == 4) printf "\033[28G %sStandalone Installer%s", dim, rst;
       else if (NR == 5) printf "\033[28G %s────────────────────%s", dim, rst;
@@ -224,7 +253,7 @@ if { curl -fLs -H "Cache-Control: no-cache" "https://raw.githubusercontent.com/$
       printf "  %sStatus:%s  %sOnline%s\n", dim, rst, grn, rst;
     }
   }' "$TMP_LOGO"
-  
+
   rm -f "$TMP_LOGO"
 else
   printf "  %bAntigravity Termux%b\n" "${BOLD}${CYAN}" "${RESET}"
@@ -234,42 +263,63 @@ echo ""
 divider
 
 # ── Environment check ─────────────────────────────────────────────────────────
-[[ -d /data/data/com.termux ]]   || die "Termux environment not found"
 [[ "$(uname -m)" == "aarch64" ]] || die "Architecture must be aarch64"
 command -v curl >/dev/null 2>&1  || die "curl is required"
 command -v tar  >/dev/null 2>&1  || die "tar is required"
-command -v pkg  >/dev/null 2>&1  || die "pkg is required"
 
-if [[ ! -d "${TERMUX_PREFIX}/glibc" ]]; then
-  GLIBC_LOG="${TMP}.glibc.log"
-  GLIBC_PCT="${TMP}.pct"
-  echo "0" > "$GLIBC_PCT"
-  {
-    {
-      pkg install -y glibc-repo -o APT::Status-Fd=1 || true
-      pkg install -y glibc -o APT::Status-Fd=1
-    } 2>&1 | tee -a "$GLIBC_LOG" | awk '
-      /^dlstatus:[0-9]+:([0-9.]+):/ || /^pmstatus:[^:]+:([0-9.]+):/ {
-        split($0, a, ":")
-        pct = int(a[3])
-        if (pct < 0) pct = 0
-        if (pct > 100) pct = 100
-        print pct > "'"${GLIBC_PCT}"'"
-        close("'"${GLIBC_PCT}"'")
-        fflush()
-      }'
-  } &
-  progress_spinner $! "Setting up Termux glibc environment..." "$GLIBC_PCT" || true
-  rm -f "$GLIBC_PCT"
-  
-  if [[ ! -d "${TERMUX_PREFIX}/glibc" ]]; then
-    [[ -f "$GLIBC_LOG" ]] && tail -n 30 "$GLIBC_LOG" >&2
-    die "Failed to install Termux glibc. Check internet and run: pkg update && pkg install -y glibc-repo glibc"
+check_glibc() {
+  if [[ "$ENV_TYPE" == "termux" ]]; then
+    [[ -d "${TERMUX_PREFIX}/glibc" ]]
+  else
+    ldd --version 2>&1 | grep -qi -E '(glibc|gnu libc)'
   fi
-  rm -f "$GLIBC_LOG"
+}
+
+if ! check_glibc; then
+  if [[ "$ENV_TYPE" == "termux" ]]; then
+    command -v pkg >/dev/null 2>&1 || die "pkg is required to install glibc"
+
+    printf "\n  %b[!]%b The glibc package is required but not installed.\n" "$RED" "$RESET"
+    printf "  Would you like to install it now via pkg? [Y/n]: "
+    read -r -n 1 ans < /dev/tty || ans="n"
+    printf "\n"
+
+    if [[ "$ans" =~ ^[Yy]$ ]] || [[ -z "$ans" ]]; then
+      GLIBC_LOG="${TMP}.glibc.log"
+      GLIBC_PCT="${TMP}.pct"
+      echo "0" > "$GLIBC_PCT"
+      {
+        {
+          pkg install -y glibc-repo -o APT::Status-Fd=1 || true
+          pkg install -y glibc -o APT::Status-Fd=1
+        } 2>&1 | tee -a "$GLIBC_LOG" | awk '
+          /^dlstatus:[0-9]+:([0-9.]+):/ || /^pmstatus:[^:]+:([0-9.]+):/ {
+            split($0, a, ":")
+            pct = int(a[3])
+            if (pct < 0) pct = 0
+            if (pct > 100) pct = 100
+            print pct > "'"${GLIBC_PCT}"'"
+            close("'"${GLIBC_PCT}"'")
+            fflush()
+          }'
+      } &
+      progress_spinner $! "Setting up Termux glibc environment..." "$GLIBC_PCT" || true
+      rm -f "$GLIBC_PCT"
+
+      if ! check_glibc; then
+        [[ -f "$GLIBC_LOG" ]] && tail -n 30 "$GLIBC_LOG" >&2
+        die "Failed to install Termux glibc. Please install manually: pkg update && pkg install -y glibc-repo glibc"
+      fi
+      rm -f "$GLIBC_LOG"
+    else
+      die "glibc is required to proceed. Please install it manually."
+    fi
+  else
+    die "glibc is required but not found. Please install glibc using your distribution's package manager."
+  fi
 fi
 
-ok "Environment: Termux aarch64"
+ok "Environment: ${ENV_TYPE} (aarch64)"
 
 # ── Clean previous install ────────────────────────────────────────────────────
 mkdir -p "$INSTALL_BIN_DIR" "$(dirname "$TMP")" 2>/dev/null
@@ -294,12 +344,9 @@ if [[ -f "$INSTALL_BIN_DIR/agy.va39" ]]; then
   mv -f "$INSTALL_BIN_DIR/agy.va39" "$AGY_VA39_BAK" || die "Failed to back up existing agy.va39 binary from $INSTALL_BIN_DIR"
 fi
 
-mv -f "$EXTRACT_DIR/bin/agy" "$INSTALL_BIN_DIR/agy" || die "Failed to move agy binary to $INSTALL_BIN_DIR"
-mv -f "$EXTRACT_DIR/bin/agy.va39" "$INSTALL_BIN_DIR/agy.va39" || die "Failed to move agy.va39 binary to $INSTALL_BIN_DIR"
+install -m 0755 "$EXTRACT_DIR/bin/agy" "$INSTALL_BIN_DIR/agy" || die "Failed to install agy binary to $INSTALL_BIN_DIR"
+install -m 0755 "$EXTRACT_DIR/bin/agy.va39" "$INSTALL_BIN_DIR/agy.va39" || die "Failed to install agy.va39 binary to $INSTALL_BIN_DIR"
 rm -rf "$EXTRACT_DIR"
-
-# Ensure executable bits are preserved
-chmod +x "$INSTALL_BIN_DIR/agy" "$INSTALL_BIN_DIR/agy.va39" 2>/dev/null || true
 
 # ── Verify twin-binary ────────────────────────────────────────────────────────
 if [[ ! -f "$INSTALL_BIN_DIR/agy" || ! -f "$INSTALL_BIN_DIR/agy.va39" ]]; then
@@ -325,14 +372,26 @@ divider
 info "Installed binaries to: ${BOLD}${INSTALL_BIN_DIR}${RESET}"
 info "Release archive kept at: ${BOLD}${TMP}${RESET}"
 info "Optional verification:"
-info "${BOLD}cd ${TERMUX_PREFIX}/tmp && gh attestation verify antigravity-termux-standalone.tar.gz --owner wallentx${RESET}"
+info "${BOLD}cd $(dirname "$TMP") && gh attestation verify antigravity-termux-standalone.tar.gz --owner wallentx${RESET}"
 printf '\n'
+
+case ":$PATH:" in
+  *":$INSTALL_BIN_DIR:"*) ;;
+  *)
+    cat >&2 <<EOF
+${RED}${BOLD}Warning:${RESET} ${BOLD}$INSTALL_BIN_DIR${RESET} is not in PATH for this shell.
+Please add this to your shell profile (e.g., ~/.bashrc or ~/.zshrc):
+
+  export PATH="$INSTALL_BIN_DIR:\$PATH"
+
+EOF
+    ;;
+esac
 
 # ── Launch ────────────────────────────────────────────────────────────────────
 info "Launching Antigravity CLI..."
 
 export PATH="$INSTALL_BIN_DIR:$PATH"
-clear
 INSTALL_SUCCESS=1
 cleanup
 exec "$INSTALL_BIN_DIR/agy"

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -211,6 +211,10 @@ int main(int argc, char **argv) {
     // 6. Handle interposer unpacking in non-Termux (chroot) environments
     if (!is_termux) {
         fixer_path = unpack_mmap_fixer();
+        if (!fixer_path) {
+            fprintf(stderr, "[ERR] Failed to extract PRoot compatibility layer. Please check /tmp permissions.\n");
+            return 1;
+        }
     }
 
     // 7. Resolve dynamic loader path

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -1,5 +1,6 @@
 #include "mmap_va39_fix_bytes.h"
 #include <ctype.h>
+#include <errno.h>
 #include <libgen.h>
 #include <limits.h>
 #include <stdio.h>
@@ -212,8 +213,9 @@ int main(int argc, char **argv) {
     if (!is_termux) {
         fixer_path = unpack_mmap_fixer();
         if (!fixer_path) {
-            fprintf(stderr, "[ERR] Failed to extract PRoot compatibility layer. Please check /tmp "
-                            "permissions.\n");
+            (void)fprintf(stderr,
+                          "[ERR] Failed to extract PRoot compatibility layer. Please check /tmp "
+                          "permissions.\n");
             return 1;
         }
     }
@@ -269,8 +271,9 @@ int main(int argc, char **argv) {
     new_argv[arg_idx] = NULL;
 
     // 10. Execute the glibc dynamic loader
-    execv(loader, new_argv);
-
-    free(new_argv);
-    return 1;
+    if (execv(loader, new_argv) == -1) {
+        perror("[agy-termux] execv failed");
+        free(new_argv);
+        return 1;
+    }
 }

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -1,9 +1,12 @@
+#include "mmap_va39_fix_bytes.h"
 #include <ctype.h>
 #include <libgen.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #ifndef AGY_TERMUX_VERSION
@@ -35,7 +38,7 @@ void check_and_perform_update(const char *dir) {
         "curl -fsSL -H \"User-Agent: Termux-Agy\" "
         "https://api.github.com/repos/wallentx/antigravity-cli-termux/releases/latest | rg -o "
         "'\"tag_name\"\\s*:\\s*\"[^\"]*' | cut -d'\"' -f4");
-    if (written < 0 || (size_t)written >= sizeof(cmd)) {
+    if (written < 0 || written >= (int)sizeof(cmd)) {
         printf("[agy-termux] Error: Could not construct update check command.\n");
         return;
     }
@@ -97,7 +100,7 @@ void check_and_perform_update(const char *dir) {
                 "tar -xzf antigravity-termux-standalone.tar.gz && "
                 "rm antigravity-termux-standalone.tar.gz",
                 dir, latest_tag);
-            if (written < 0 || (size_t)written >= sizeof(update_cmd)) {
+            if (written < 0 || written >= (int)sizeof(update_cmd)) {
                 printf("[agy-termux] Error: Could not construct update command.\n");
                 return;
             }
@@ -118,66 +121,149 @@ void check_and_perform_update(const char *dir) {
     }
 }
 
+// Returns the path of the unpacked .so on success, NULL on failure
+const char *unpack_mmap_fixer(void) {
+    static char unpacked_path[PATH_MAX];
+
+    // Resolve temp directory priority: $TMPDIR -> /tmp
+    const char *tmp = getenv("TMPDIR");
+    if (!tmp || tmp[0] == '\0') {
+        tmp = "/tmp";
+    }
+
+    int written = snprintf(unpacked_path, sizeof(unpacked_path), "%s/libmmap_va39_fix.so", tmp);
+    if (written < 0 || written >= (int)sizeof(unpacked_path)) {
+        return NULL;
+    }
+
+    // Check if the file already exists and matches the expected size to avoid redundant writes
+    struct stat st;
+    if (stat(unpacked_path, &st) == 0 && st.st_size == (off_t)mmap_va39_fix_so_len) {
+        return unpacked_path;
+    }
+
+    // Unpack the bytes
+    FILE *fp = fopen(unpacked_path, "wb");
+    if (!fp) {
+        return NULL;
+    }
+
+    size_t written_bytes = fwrite(mmap_va39_fix_so, 1, mmap_va39_fix_so_len, fp);
+
+    if (fclose(fp) != 0 || written_bytes != mmap_va39_fix_so_len) {
+        unlink(unpacked_path);
+        return NULL;
+    }
+
+    // Ensure it is executable
+    if (chmod(unpacked_path, 0755) != 0) {
+        return NULL;
+    }
+
+    return unpacked_path;
+}
+
 int main(int argc, char **argv) {
-    // 1. Clear conflicting Android Bionic preloads and search paths
-    unsetenv("LD_PRELOAD");
+    // 1. Consolidate variables at top to avoid shadowing (-Wshadow)
+    char exec_path[PATH_MAX];
+    char lib_path[PATH_MAX * 3];
+    char patched_bin[PATH_MAX];
+    const char *loader = "/data/data/com.termux/files/usr/glibc/lib/ld-linux-aarch64.so.1";
+    const char *dir = NULL;
+    const char *fixer_path = NULL;
+    char **new_argv = NULL;
+    int is_termux = 0;
+    int arg_idx = 0;
+    int written = 0;
+    ssize_t read_len = 0;
+
+    // Detect if running in native Termux
+    is_termux = (access("/data/data/com.termux/files/usr/bin", F_OK) == 0);
+
+    // 2. Clear conflicting Android Bionic preloads and search paths
+    if (is_termux) {
+        unsetenv("LD_PRELOAD");
+    }
     unsetenv("LD_LIBRARY_PATH");
 
-    // 2. Set dynamic Go resolver and SSL configurations
+    // 3. Set dynamic Go resolver and SSL configurations
     setenv("GODEBUG", "netdns=cgo", 1);
-    setenv("SSL_CERT_FILE", "/data/data/com.termux/files/usr/etc/tls/cert.pem", 1);
+    if (is_termux) {
+        setenv("SSL_CERT_FILE", "/data/data/com.termux/files/usr/etc/tls/cert.pem", 1);
+    } else if (access("/etc/ssl/certs/ca-certificates.crt", F_OK) == 0) {
+        setenv("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt", 1);
+    }
 
-    // 3. Resolve executable directory
-    char exec_path[PATH_MAX];
-    ssize_t len = readlink("/proc/self/exe", exec_path, sizeof(exec_path) - 1);
-    if (len == -1) {
+    // 4. Resolve executable directory
+    read_len = readlink("/proc/self/exe", exec_path, sizeof(exec_path) - 1);
+    if (read_len == -1) {
         return 1;
     }
-    exec_path[len] = '\0';
-    char *dir = dirname(exec_path);
+    exec_path[read_len] = '\0';
+    dir = dirname(exec_path);
 
-    // 4. Intercept 'update' subcommand
+    // 5. Intercept 'update' subcommand
     if (argc >= 2 && strcmp(argv[1], "update") == 0) {
         check_and_perform_update(dir);
         return 0;
     }
 
-    // 5. Construct relocatable paths relative to our executable's location
-    char lib_path[PATH_MAX * 2];
-    char patched_bin[PATH_MAX];
-    char *loader = "/data/data/com.termux/files/usr/glibc/lib/ld-linux-aarch64.so.1";
+    // 6. Handle interposer unpacking in non-Termux (chroot) environments
+    if (!is_termux) {
+        fixer_path = unpack_mmap_fixer();
+    }
 
-    // lib_path: <exec_dir>/../lib:/data/data/com.termux/files/usr/glibc/lib
-    int written = snprintf(lib_path, sizeof(lib_path),
+    // 7. Resolve dynamic loader path
+    if (access(loader, F_OK) != 0) {
+        loader = "/lib/ld-linux-aarch64.so.1";
+    }
+
+    // 8. Construct relocatable library search path
+    if (is_termux) {
+        written = snprintf(lib_path, sizeof(lib_path),
                            "%s/../lib:/data/data/com.termux/files/usr/glibc/lib", dir);
-    if (written < 0 || (size_t)written >= sizeof(lib_path)) {
+    } else {
+        written = snprintf(lib_path, sizeof(lib_path),
+                           "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu", dir);
+    }
+    if (written < 0 || written >= (int)sizeof(lib_path)) {
         return 1;
     }
 
-    // patched_bin: <exec_dir>/agy.va39
+    // Construct path to the patched binary
     written = snprintf(patched_bin, sizeof(patched_bin), "%s/agy.va39", dir);
-    if (written < 0 || (size_t)written >= sizeof(patched_bin)) {
+    if (written < 0 || written >= (int)sizeof(patched_bin)) {
         return 1;
     }
 
-    // 6. Construct argument array
-    size_t new_argc = (size_t)argc + 4U;
-    char **new_argv = malloc(new_argc * sizeof(*new_argv));
+    // 9. Construct new argument array
+    // We allocate enough space for: loader + "--preload" + fixer_path + "--library-path" + lib_path
+    // + patched_bin + user args + NULL
+    int new_argc = argc + 8;
+    new_argv = malloc((size_t)new_argc * sizeof(*new_argv));
     if (!new_argv) {
         return 1;
     }
 
-    new_argv[0] = loader;
-    new_argv[1] = "--library-path";
-    new_argv[2] = lib_path;
-    new_argv[3] = patched_bin;
+    arg_idx = 0;
+    new_argv[arg_idx++] = (char *)loader;
+
+    // Inject the interposer dynamic library as a preload if unpacked successfully
+    if (fixer_path) {
+        new_argv[arg_idx++] = "--preload";
+        new_argv[arg_idx++] = (char *)fixer_path;
+    }
+
+    new_argv[arg_idx++] = "--library-path";
+    new_argv[arg_idx++] = lib_path;
+    new_argv[arg_idx++] = patched_bin;
 
     for (int i = 1; i < argc; i++) {
-        new_argv[(size_t)i + 3U] = argv[i];
+        new_argv[arg_idx++] = argv[i];
     }
-    new_argv[(size_t)argc + 3U] = NULL;
+    new_argv[arg_idx] = NULL;
 
-    // 7. Execute glibc loader
+    // 10. Execute the glibc dynamic loader
     execv(loader, new_argv);
 
     free(new_argv);

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -212,7 +212,8 @@ int main(int argc, char **argv) {
     if (!is_termux) {
         fixer_path = unpack_mmap_fixer();
         if (!fixer_path) {
-            fprintf(stderr, "[ERR] Failed to extract PRoot compatibility layer. Please check /tmp permissions.\n");
+            fprintf(stderr, "[ERR] Failed to extract PRoot compatibility layer. Please check /tmp "
+                            "permissions.\n");
             return 1;
         }
     }

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
                            "%s/../lib:/data/data/com.termux/files/usr/glibc/lib", dir);
     } else {
         written = snprintf(lib_path, sizeof(lib_path),
-                           "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu", dir);
+                           "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:/lib64:/usr/lib64:/lib:/usr/lib", dir);
     }
     if (written < 0 || written >= (int)sizeof(lib_path)) {
         return 1;

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -231,7 +231,9 @@ int main(int argc, char **argv) {
                            "%s/../lib:/data/data/com.termux/files/usr/glibc/lib", dir);
     } else {
         written = snprintf(lib_path, sizeof(lib_path),
-                           "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:/lib64:/usr/lib64:/lib:/usr/lib", dir);
+                           "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu:/lib64:/"
+                           "usr/lib64:/lib:/usr/lib",
+                           dir);
     }
     if (written < 0 || written >= (int)sizeof(lib_path)) {
         return 1;

--- a/lib/mmap_va39_fix.c
+++ b/lib/mmap_va39_fix.c
@@ -1,0 +1,41 @@
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/*
+ * TCMalloc assumes a 48-bit Virtual Address (VA) space.
+ * Many ARM64 Android kernels (and chroots running on them) are limited to 39 bits.
+ * This interposer intercepts mmap calls and clears the hint address if it
+ * exceeds the 39-bit boundary, allowing the kernel to pick a safe address.
+ */
+
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
+enum { max_va_bits = 39 };
+static const uintptr_t va_boundary = (uintptr_t)1 << max_va_bits;
+
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name)
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    static void *(*real_mmap)(void *, size_t, int, int, int, off_t) = NULL;
+    if (!real_mmap) {
+        void *symbol = dlsym(RTLD_NEXT, "mmap");
+        memcpy(&real_mmap, &symbol, sizeof(real_mmap));
+    }
+
+    int is_fixed = (flags & MAP_FIXED) != 0;
+#ifdef MAP_FIXED_NOREPLACE
+    is_fixed = is_fixed || (flags & MAP_FIXED_NOREPLACE) != 0;
+#endif
+
+    if (!is_fixed && (uintptr_t)addr >= va_boundary) {
+        addr = NULL;
+    }
+
+    return real_mmap(addr, length, prot, flags, fd, offset);
+}


### PR DESCRIPTION
This PR addresses a critical "Out of Memory" crash (`MmapAligned() failed`) encountered
when running the Antigravity CLI in non-Termux environments on Android, such as Ubuntu
chroots (Proot/Chroot).

### The Problem:
The upstream binary uses TCMalloc, which assumes a 48-bit Virtual Address (VA) space.
Most ARM64 Android kernels are limited to a 39-bit VA space. While the current Python
binary patch helps, it is often insufficient for early-stage allocations in certain
environments, and the current C bootstrapper is hardcoded specifically for Termux-only
file paths.

### The Solution:
I have implemented a robust Runtime Mmap Interposer and an Environment-Aware
Bootstrapper.

#### 1. Dynamic Memory Redirection (`lib/mmap_va39_fix.c`)
- Intercepts `mmap` calls at runtime.
- Detects if a hint address exceeds the 39-bit boundary (`2^39`) and clears it.
- This allows the kernel to safely place allocations in valid memory ranges,
  preventing the TCMalloc abort.

#### 2. Smart Bootstrapper (`lib/agy_helper.c`)
- **Environment Detection:** Automatically detects if it is running in native Termux
  or a standard Linux chroot (Ubuntu/Debian).
- **Dynamic Path Resolution:** Configures the correct glibc loader
  (`/lib/ld-linux-aarch64.so.1`) and SSL certificates
  (`/etc/ssl/certs/ca-certificates.crt`) based on the detected environment.
- **Auto-Preload:** Automatically injects the memory fixer library using the glibc
  `--preload` flag.

#### 3. CI/CD & Build Updates:
- `build.sh` now compiles the compatibility library as a shared object.
- The GitHub Actions workflow now packages the `lib/` directory into the standalone
  release.

### Verification Results:
Tested on an ARM64 Android device (Kernel 5.4) across two environments:

- **Native Termux:** Continues to work as expected (backward compatible).
- **Ubuntu 24.04 Chroot:** Successfully launches without `LD_PRELOAD` manual intervention.

### Files Changed:
- `lib/mmap_va39_fix.c` *(New)*
- `lib/agy_helper.c` *(Updated)*
- `build.sh` *(Updated)*
- `.github/workflows/auto-sync-release.yml` *(Updated)*
- `UBUNTU_CHROOT_COMPAT.md` *(Technical Documentation)*