### PR TITLE
ci(termux): Add emulator probe workflow for Termux environment testing

### DIFF
--- a/.github/workflows/termux-run.yml
+++ b/.github/workflows/termux-run.yml
@@ -1,0 +1,193 @@
+name: Termux Emulator Probe
+
+on:
+  workflow_dispatch:
+    inputs:
+      termux_channel:
+        description: Termux APK release channel
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+      require_aarch64:
+        description: Fail unless Termux reports aarch64
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: termux-emulator-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  api35-x86_64:
+    name: API 35 x86_64 Termux probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      TERMUX_HOME: /data/data/com.termux/files/home
+      TERMUX_PREFIX: /data/data/com.termux/files/usr
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download Termux APK
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TERMUX_CHANNEL: ${{ inputs.termux_channel }}
+        run: |
+          set -euo pipefail
+
+          gh api repos/termux/termux-app/releases > termux-releases.json
+
+          if [[ "$TERMUX_CHANNEL" == "stable" ]]; then
+            apk_url=$(jq -r '[.[] | select(.draft == false and .prerelease == false) | .assets[] | select(.name | test("(apt-android-7.*github-debug_universal|github-debug_universal)\\.apk$")) | .browser_download_url][0] // empty' termux-releases.json)
+          else
+            apk_url=$(jq -r '[.[] | select(.draft == false) | .assets[] | select(.name | test("(apt-android-7.*github-debug_universal|github-debug_universal)\\.apk$")) | .browser_download_url][0] // empty' termux-releases.json)
+          fi
+
+          if [[ -z "$apk_url" ]]; then
+            echo "No matching Termux GitHub-debug universal APK was found." >&2
+            exit 1
+          fi
+
+          curl --fail --location --retry 3 --retry-delay 5 "$apk_url" --output termux.apk
+          printf 'TERMUX_APK_URL=%s\n' "$apk_url" >> "$GITHUB_ENV"
+
+      - name: Enable KVM
+        run: |
+          set -euo pipefail
+
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Probe Termux in Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          REQUIRE_AARCH64: ${{ inputs.require_aarch64 }}
+        with:
+          api-level: 35
+          target: google_apis
+          arch: x86_64
+          profile: pixel_5
+          force-avd-creation: false
+          emulator-options: -no-snapshot-load -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          disable-animations: true
+          script: |
+            set -euo pipefail
+
+            probe_file=termux-emulator-probe.env
+            : > "$probe_file"
+            trap 'adb logcat -d > termux-emulator-logcat.txt 2>/dev/null || true' EXIT
+
+            record() {
+              printf '%s=%s\n' "$1" "$2" | tee -a "$probe_file"
+            }
+
+            termux_exec() {
+              local command_line=$1
+
+              adb shell run-as com.termux env \
+                "HOME=$TERMUX_HOME" \
+                "PREFIX=$TERMUX_PREFIX" \
+                "TMPDIR=$TERMUX_PREFIX/tmp" \
+                "TERMUX_VERSION=ci" \
+                "PATH=$TERMUX_PREFIX/bin:/system/bin:/system/xbin" \
+                "$TERMUX_PREFIX/bin/bash" -lc "$command_line"
+            }
+
+            wait_for_termux_bootstrap() {
+              local attempt
+
+              for attempt in {1..120}; do
+                if adb shell run-as com.termux test -x files/usr/bin/bash >/dev/null 2>&1; then
+                  return 0
+                fi
+                sleep 2
+              done
+
+              return 1
+            }
+
+            device_abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')
+            device_abilist=$(adb shell getprop ro.product.cpu.abilist | tr -d '\r')
+            record ANDROID_CPU_ABI "$device_abi"
+            record ANDROID_CPU_ABILIST "$device_abilist"
+            record TERMUX_APK_URL "$TERMUX_APK_URL"
+
+            adb install -r termux.apk
+            adb shell pm grant com.termux android.permission.POST_NOTIFICATIONS || true
+            adb shell monkey -p com.termux -c android.intent.category.LAUNCHER 1 >/dev/null
+
+            if ! wait_for_termux_bootstrap; then
+              echo "Termux did not finish bootstrap within the timeout." >&2
+              exit 1
+            fi
+
+            termux_arch=$(termux_exec 'uname -m' | tr -d '\r')
+            termux_dpkg_arch=$(termux_exec 'dpkg --print-architecture 2>/dev/null || true' | tr -d '\r')
+            termux_loader_state=$(termux_exec 'test -e /data/data/com.termux/files/usr/glibc/lib/ld-linux-aarch64.so.1 && echo present || echo missing' | tr -d '\r')
+
+            record TERMUX_UNAME_M "$termux_arch"
+            record TERMUX_DPKG_ARCH "$termux_dpkg_arch"
+            record TERMUX_AARCH64_GLIBC_LOADER "$termux_loader_state"
+
+            {
+              echo "### Termux Emulator Probe"
+              echo ""
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              sed 's/|/\\|/g; s/^\([^=]*\)=\(.*\)$/| `\1` | `\2` |/' "$probe_file"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [[ "$termux_arch" != "aarch64" && "$REQUIRE_AARCH64" == "true" ]]; then
+              echo "Termux reported $termux_arch, but require_aarch64 was enabled." >&2
+              exit 1
+            fi
+
+            if [[ "$termux_arch" != "aarch64" ]]; then
+              echo "Termux reported $termux_arch; skipping the v1.0.6 aarch64 release smoke test."
+              exit 0
+            fi
+
+            cat > termux-release-smoke.sh <<'TERMUX_RELEASE_SMOKE'
+            set -euo pipefail
+
+            mkdir -p "$HOME/agy-smoke"
+            cd "$HOME/agy-smoke"
+
+            pkg install ca-certificates glibc-repo -y
+            pkg install glibc-runner -y
+            curl -fsSLO https://github.com/wallentx/antigravity-cli-termux/releases/download/v1.0.6/antigravity-termux-standalone.tar.gz
+            tar -xzf antigravity-termux-standalone.tar.gz
+            ./bin/agy --help
+            TERMUX_RELEASE_SMOKE
+
+            adb push termux-release-smoke.sh /data/local/tmp/termux-release-smoke.sh >/dev/null
+            adb shell chmod 0644 /data/local/tmp/termux-release-smoke.sh
+            termux_exec 'bash /data/local/tmp/termux-release-smoke.sh'
+
+      - name: Upload emulator diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: termux-emulator-diagnostics
+          path: |
+            termux-emulator-logcat.txt
+            termux-emulator-probe.env
+            termux-releases.json
+          if-no-files-found: ignore

--- a/.github/workflows/termux-run.yml
+++ b/.github/workflows/termux-run.yml
@@ -170,6 +170,7 @@ jobs:
             mkdir -p "$HOME/agy-smoke"
             cd "$HOME/agy-smoke"
 
+            pkg update -y
             pkg install ca-certificates glibc-repo -y
             pkg install glibc-runner -y
             curl -fsSLO https://github.com/wallentx/antigravity-cli-termux/releases/download/v1.0.6/antigravity-termux-standalone.tar.gz


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the probing and validation of the Termux app inside an Android emulator. The workflow allows for flexible selection of Termux APK release channels, checks the emulator and Termux environment, and performs a smoke test for the aarch64 architecture. It also collects and uploads diagnostics for further analysis.

Key additions in this workflow:

**Automated Termux Emulator Testing:**
* Adds a new workflow file `.github/workflows/termux-run.yml` that provisions an Android emulator, installs Termux, and runs a series of checks to verify the environment and Termux installation.
* Supports manual triggering with input parameters for Termux release channel selection (`stable` or `latest`) and an option to require aarch64 architecture.

**Environment Probing and Reporting:**
* Probes the emulator and Termux environment (including CPU ABI, Termux architecture, and glibc loader presence), and summarizes results in the GitHub Actions step summary.
* Performs a smoke test of the `antigravity-cli-termux` release if the environment is aarch64, ensuring compatibility and correct setup.

**Diagnostics and Artifacts:**
* Collects emulator logs and probe results, uploading them as workflow artifacts for debugging