### PR TITLE
ci: add Termux Run Dockerify workflow for ARM64 free runner

### DIFF
--- a/.github/workflows/termux-run-dockerify.yml
+++ b/.github/workflows/termux-run-dockerify.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - dev
-      - main
   workflow_dispatch:
     inputs:
       termux_channel:

--- a/.github/workflows/termux-run-dockerify.yml
+++ b/.github/workflows/termux-run-dockerify.yml
@@ -1,0 +1,178 @@
+name: Termux Run Dockerify
+
+on:
+  workflow_run:
+    workflows:
+      - Pull Request Validation
+    types:
+      - completed
+  push:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
+    inputs:
+      termux_channel:
+        description: Termux APK release channel
+        required: true
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+      extra_commands:
+        description: Additional Termux commands to run inside the emulator
+        required: false
+        type: string
+        default: ""
+      extra_commands_at_start:
+        description: Run additional commands before default package setup
+        required: true
+        type: boolean
+        default: false
+      release_tag:
+        description: Release tag to download and smoke-test inside Termux
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: termux-dockerify-probe-${{ github.event.workflow_run.id || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  arm64-dockerify:
+    name: ARM64 Dockerify Termux probe
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      TERMUX_HOME: /data/data/com.termux/files/home
+      TERMUX_PREFIX: /data/data/com.termux/files/usr
+      TERMUX_INSTALL_ABI: arm64-v8a
+      TERMUX_CHANNEL_INPUT: ${{ inputs.termux_channel || 'stable' }}
+      TERMUX_RELEASE_TEST_TAG: ${{ inputs.release_tag || '' }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Download Termux APK
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TERMUX_CHANNEL: ${{ env.TERMUX_CHANNEL_INPUT }}
+          TERMUX_INSTALL_ABI: ${{ env.TERMUX_INSTALL_ABI }}
+        run: |
+          ./.github/scripts/download-termux-apk.sh
+
+      - name: Download PR standalone archive
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          ./.github/scripts/download-pr-check-artifact.sh
+
+      - name: Install adb and start Dockerify Android
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y adb
+          
+          # Check KVM availability
+          ls -la /dev/kvm || true
+          
+          # Start dockerify-android container
+          docker run -d \
+            --name dockerify-android \
+            --privileged \
+            --device /dev/kvm \
+            -p 5555:5555 \
+            -p 8000:8000 \
+            shmayro/dockerify-android:latest
+
+      - name: Wait for emulator to boot
+        run: |
+          echo "Waiting for ADB connection..."
+          for _ in {1..90}; do
+            if adb connect localhost:5555 | grep -q "connected"; then
+              echo "Connected to emulator via ADB!"
+              break
+            fi
+            sleep 2
+          done
+          
+          echo "Waiting for device to be online..."
+          for _ in {1..90}; do
+            status=$(adb -s localhost:5555 get-state 2>/dev/null || true)
+            if [ "$status" = "device" ]; then
+              echo "Device is online!"
+              break
+            fi
+            sleep 2
+          done
+          
+          echo "Waiting for system boot completion..."
+          for _ in {1..120}; do
+            boot_completed=$(adb -s localhost:5555 shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
+            if [ "$boot_completed" = "1" ]; then
+              echo "System booted successfully!"
+              break
+            fi
+            sleep 2
+          done
+          
+          # Show active devices
+          adb devices -l
+
+      - name: Probe Termux in Dockerify Android
+        env:
+          TERMUX_BOOTSTRAP_ATTEMPTS: 240
+          TERMUX_INSTALL_ABI: ${{ env.TERMUX_INSTALL_ABI }}
+          TERMUX_RESTORE_SNAPSHOT: false
+          TERMUX_RESTORED_AVD_CACHE: false
+          TERMUX_SAVE_SNAPSHOT: false
+          TERMUX_EXTRA_COMMANDS: ${{ inputs.extra_commands || '' }}
+          TERMUX_EXTRA_COMMANDS_AT_START: ${{ inputs.extra_commands_at_start || false }}
+          TERMUX_RELEASE_TEST_TAG: ${{ env.TERMUX_RELEASE_TEST_TAG }}
+        run: |
+          bash .github/scripts/termux-emulator-probe.sh
+
+      - name: Capture emulator diagnostic files
+        if: always()
+        run: |
+          adb logcat -d > termux-emulator-logcat.txt 2>/dev/null || true
+          for dir in $(adb shell run-as com.termux find /data/data/com.termux/files/home/ -maxdepth 1 -name ".termux-probe-results-*" 2>/dev/null | tr -d '\r'); do
+            if [ -n "$dir" ]; then
+              base=$(basename "$dir")
+              echo "=== Captured stdout for $base ===" > "termux-stdout-$base.txt"
+              adb shell run-as com.termux cat "$dir/stdout" >> "termux-stdout-$base.txt" 2>/dev/null || true
+              echo "=== Captured stderr for $base ===" > "termux-stderr-$base.txt"
+              adb shell run-as com.termux cat "$dir/stderr" >> "termux-stderr-$base.txt" 2>/dev/null || true
+              echo "=== Captured status for $base ===" > "termux-status-$base.txt"
+              adb shell run-as com.termux cat "$dir/status" >> "termux-status-$base.txt" 2>/dev/null || true
+            fi
+          done
+
+      - name: Upload emulator diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: termux-dockerify-diagnostics
+          path: |
+            termux-emulator-logcat.txt
+            termux-emulator-probe.env
+            termux-releases.json
+            termux-stdout-*.txt
+            termux-stderr-*.txt
+            termux-status-*.txt
+            termux-pr-artifact/antigravity-termux-standalone.tar.gz
+          if-no-files-found: ignore

--- a/.github/workflows/termux-run-dockerify.yml
+++ b/.github/workflows/termux-run-dockerify.yml
@@ -109,33 +109,51 @@ jobs:
       - name: Wait for emulator to boot
         run: |
           echo "Waiting for ADB connection..."
+          connected=false
           for _ in {1..90}; do
             if adb connect localhost:5555 | grep -q "connected"; then
               echo "Connected to emulator via ADB!"
+              connected=true
               break
             fi
             sleep 2
           done
+          if [ "$connected" != "true" ]; then
+            echo "Failed to connect to ADB daemon." >&2
+            exit 1
+          fi
           
           echo "Waiting for device to be online..."
+          online=false
           for _ in {1..90}; do
             status=$(adb -s localhost:5555 get-state 2>/dev/null || true)
             if [ "$status" = "device" ]; then
               echo "Device is online!"
+              online=true
               break
             fi
             sleep 2
           done
+          if [ "$online" != "true" ]; then
+            echo "Device never came online." >&2
+            exit 1
+          fi
           
           echo "Waiting for system boot completion..."
+          booted=false
           for _ in {1..120}; do
             boot_completed=$(adb -s localhost:5555 shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
             if [ "$boot_completed" = "1" ]; then
               echo "System booted successfully!"
+              booted=true
               break
             fi
             sleep 2
           done
+          if [ "$booted" != "true" ]; then
+            echo "System boot timed out." >&2
+            exit 1
+          fi
           
           # Show active devices
           adb devices -l

--- a/.github/workflows/termux-run-dockerify.yml
+++ b/.github/workflows/termux-run-dockerify.yml
@@ -86,17 +86,25 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y adb
           
-          # Check KVM availability
-          ls -la /dev/kvm || true
-          
-          # Start dockerify-android container
-          docker run -d \
-            --name dockerify-android \
-            --privileged \
-            --device /dev/kvm \
-            -p 5555:5555 \
-            -p 8000:8000 \
-            shmayro/dockerify-android:latest
+          # Start dockerify-android container with KVM if available
+          if [ -e /dev/kvm ]; then
+            echo "KVM is available. Starting with hardware acceleration."
+            docker run -d \
+              --name dockerify-android \
+              --privileged \
+              --device /dev/kvm \
+              -p 5555:5555 \
+              -p 8000:8000 \
+              shmayro/dockerify-android:latest
+          else
+            echo "KVM is NOT available. Starting in software emulation mode."
+            docker run -d \
+              --name dockerify-android \
+              --privileged \
+              -p 5555:5555 \
+              -p 8000:8000 \
+              shmayro/dockerify-android:latest
+          fi
 
       - name: Wait for emulator to boot
         run: |
@@ -148,18 +156,22 @@ jobs:
       - name: Capture emulator diagnostic files
         if: always()
         run: |
-          adb logcat -d > termux-emulator-logcat.txt 2>/dev/null || true
-          for dir in $(adb shell run-as com.termux find /data/data/com.termux/files/home/ -maxdepth 1 -name ".termux-probe-results-*" 2>/dev/null | tr -d '\r'); do
-            if [ -n "$dir" ]; then
-              base=$(basename "$dir")
-              echo "=== Captured stdout for $base ===" > "termux-stdout-$base.txt"
-              adb shell run-as com.termux cat "$dir/stdout" >> "termux-stdout-$base.txt" 2>/dev/null || true
-              echo "=== Captured stderr for $base ===" > "termux-stderr-$base.txt"
-              adb shell run-as com.termux cat "$dir/stderr" >> "termux-stderr-$base.txt" 2>/dev/null || true
-              echo "=== Captured status for $base ===" > "termux-status-$base.txt"
-              adb shell run-as com.termux cat "$dir/status" >> "termux-status-$base.txt" 2>/dev/null || true
-            fi
-          done
+          if adb devices | grep -q -E "\bdevice\b"; then
+            adb logcat -d > termux-emulator-logcat.txt 2>/dev/null || true
+            for dir in $(adb shell run-as com.termux find /data/data/com.termux/files/home/ -maxdepth 1 -name ".termux-probe-results-*" 2>/dev/null | tr -d '\r'); do
+              if [ -n "$dir" ]; then
+                base=$(basename "$dir")
+                echo "=== Captured stdout for $base ===" > "termux-stdout-$base.txt"
+                adb shell run-as com.termux cat "$dir/stdout" >> "termux-stdout-$base.txt" 2>/dev/null || true
+                echo "=== Captured stderr for $base ===" > "termux-stderr-$base.txt"
+                adb shell run-as com.termux cat "$dir/stderr" >> "termux-stderr-$base.txt" 2>/dev/null || true
+                echo "=== Captured status for $base ===" > "termux-status-$base.txt"
+                adb shell run-as com.termux cat "$dir/status" >> "termux-status-$base.txt" 2>/dev/null || true
+              fi
+            done
+          else
+            echo "No online adb devices found. Skipping adb diagnostics."
+          fi
 
       - name: Upload emulator diagnostics
         if: always()


### PR DESCRIPTION
This pull request adds the new workflow using the `shmayro/dockerify-android` Docker container on a free GitHub Actions ARM64 runner (`ubuntu-24.04-arm`) to test the Termux environment and smoke-test the Antigravity binary.