### PR TITLE
feat: restore Ubuntu chroot compatibility and support USE_NDK=0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,11 @@
 # Fetches/compiles the C bootstrapper and applies VA39 memory patches.
 set -Eeuo pipefail
 
+# Clean SSL_CERT_FILE if it points to a non-existent path (e.g. inherited Termux path in Ubuntu chroot)
+if [[ -n "${SSL_CERT_FILE:-}" && ! -f "$SSL_CERT_FILE" ]]; then
+  unset SSL_CERT_FILE
+fi
+
 # Enforce execution from the script's directory root
 cd "$(dirname "$0")"
 
@@ -40,10 +45,12 @@ Arguments:
 Environment:
   AGY_VERSION                      Version to embed when building from a local binary.
                                    Required if that binary cannot run on this host.
+  SKIP_BOOTSTRAPPER                If set to 1, skips compiling the C bootstrapper and
+                                   only generates the patched bin/agy.va39 binary.
 
 Requirements:
   - curl, jq, tar, python3
-  - native aarch64 Termux clang, or \$ANDROID_NDK_HOME with an aarch64 Android clang
+  - native aarch64 Termux clang, or \$ANDROID_NDK_HOME with an aarch64 Android clang (unless SKIP_BOOTSTRAPPER=1)
 EOF
 }
 
@@ -78,7 +85,8 @@ check_prereqs() {
 
 # Compiler detection
 detect_compiler() {
-  if [[ -n "${ANDROID_NDK_HOME:-}" ]]; then
+  USE_NDK="${USE_NDK:-1}"
+  if [[ "$USE_NDK" == "1" && -n "${ANDROID_NDK_HOME:-}" ]]; then
     local ndk_clang
     ndk_clang=$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -name "aarch64-linux-android*-clang" -print -quit 2>/dev/null)
     if [[ -n "$ndk_clang" && -x "$ndk_clang" ]]; then
@@ -97,18 +105,40 @@ detect_compiler() {
     return 0
   fi
 
+  if command -v clang &>/dev/null; then
+    echo "clang"
+    return 0
+  elif command -v gcc &>/dev/null; then
+    echo "gcc"
+    return 0
+  fi
+
   return 1
 }
 
 # Main builder logic
 check_prereqs
 
-# Detect C compiler
+SKIP_BOOTSTRAPPER="${SKIP_BOOTSTRAPPER:-0}"
+USE_NDK="${USE_NDK:-1}"
+
+# Detect C compiler and setup flags
 local_cc=""
-if ! local_cc=$(detect_compiler); then
-  die "No supported aarch64 C compiler found. Install Termux clang on aarch64, or set ANDROID_NDK_HOME with an aarch64 Android clang."
+extra_cc_flags=()
+if [[ "$SKIP_BOOTSTRAPPER" != "1" ]]; then
+  if ! local_cc=$(detect_compiler); then
+    die "No supported aarch64 C compiler found. Install clang/gcc on the host, Termux clang on aarch64, or set ANDROID_NDK_HOME with an aarch64 Android clang."
+  fi
+  info "Selected C compiler: $local_cc"
+
+  # Additional compiler flags for custom NDK/toolchains (e.g. symlinked host compilers)
+  if [[ "$USE_NDK" == "1" && -n "${ANDROID_NDK_HOME:-}" ]]; then
+    ndk_resource_dir=$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -mindepth 2 -maxdepth 5 -path "*/lib/clang/*" -type d -print -quit 2>/dev/null)
+    if [[ -n "$ndk_resource_dir" ]]; then
+      extra_cc_flags+=("--rtlib=compiler-rt" "-unwindlib=libunwind" "-resource-dir" "$ndk_resource_dir")
+    fi
+  fi
 fi
-info "Selected C compiler: $local_cc"
 
 # Create directories
 mkdir -p staging bin
@@ -230,19 +260,23 @@ print(f"Patched parameters: ubfx={ubfx_count}, lsl={lsl_count}, mask={mask_count
 PY
 ok "Patched binary generated: bin/agy.va39"
 
-# Compile the native Termux C bootstrapper.
-info "Compiling native Termux C bootstrapper..."
-if ! "$local_cc" -O2 -DAGY_TERMUX_VERSION="\"$latest_version\"" -o bin/agy lib/agy_helper.c; then
-  die "Compilation of lib/agy_helper.c failed."
-fi
-
-chmod +x bin/agy
-ok "Native Termux bootstrapper compiled successfully."
-
-if [[ -n "${TERMUX_VERSION:-}" ]]; then
-  info "Validating built Termux binary with --help..."
-  if ! bin/agy --help >/dev/null; then
-    die "Built Termux binary failed to execute with --help."
+if [[ "$SKIP_BOOTSTRAPPER" != "1" ]]; then
+  # Compile the native Termux C bootstrapper.
+  info "Compiling native Termux C bootstrapper..."
+  if ! "$local_cc" "${extra_cc_flags[@]}" -O2 -DAGY_TERMUX_VERSION="\"$latest_version\"" -o bin/agy lib/agy_helper.c; then
+    die "Compilation of lib/agy_helper.c failed."
   fi
-  ok "Built Termux binary executed successfully."
+
+  chmod +x bin/agy
+  ok "Native Termux bootstrapper compiled successfully."
+
+  if [[ -n "${TERMUX_VERSION:-}" ]]; then
+    info "Validating built Termux binary with --help..."
+    if ! bin/agy --help >/dev/null; then
+      die "Built Termux binary failed to execute with --help."
+    fi
+    ok "Built Termux binary executed successfully."
+  fi
+else
+  info "Skipping native Termux C bootstrapper compilation (SKIP_BOOTSTRAPPER=1)."
 fi

--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,7 @@ if [[ "$SKIP_BOOTSTRAPPER" != "1" ]]; then
   info "Selected C compiler: $local_cc"
 
   # Additional compiler flags for custom NDK/toolchains (e.g. symlinked host compilers)
-  if [[ "$USE_NDK" == "1" && -n "${ANDROID_NDK_HOME:-}" ]]; then
+  if [[ "$USE_NDK" == "1" && -n "${ANDROID_NDK_HOME:-}" && "$local_cc" == *clang* ]]; then
     ndk_resource_dir=$(find "$ANDROID_NDK_HOME/toolchains/llvm/prebuilt" -mindepth 2 -maxdepth 5 -path "*/lib/clang/*" -type d -print -quit 2>/dev/null)
     if [[ -n "$ndk_resource_dir" ]]; then
       extra_cc_flags+=("--rtlib=compiler-rt" "-unwindlib=libunwind" "-resource-dir" "$ndk_resource_dir")

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -7,7 +7,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/auxv.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
+#include "mmap_va39_fix_bytes.h"
 
 #ifndef HWCAP_ATOMICS
 #define HWCAP_ATOMICS (1 << 8)
@@ -239,26 +242,25 @@ static int is_native_termux(void) {
     return 1;
 }
 
-static void print_non_termux_message(void) {
-    (void)fprintf(stderr, "[agy-termux] This standalone port is only for native Termux.\n"
-                          "[agy-termux] PRoot environments can use Google's official "
-                          "Antigravity CLI binary directly.\n"
-                          "[agy-termux] Install it with:\n"
-                          "  curl -fsSL https://antigravity.google/cli/install.sh | bash\n");
-}
-
-static int require_resolver_config(const char *prefix) {
+static int require_resolver_config(const char *prefix, int is_termux) {
     char resolv_path[PATH_MAX];
-    int written = snprintf(resolv_path, sizeof(resolv_path), "%s/etc/resolv.conf", prefix);
+    int written;
+    if (is_termux) {
+        written = snprintf(resolv_path, sizeof(resolv_path), "%s/etc/resolv.conf", prefix);
+    } else {
+        written = snprintf(resolv_path, sizeof(resolv_path), "/etc/resolv.conf");
+    }
     if (written < 0 || written >= (int)sizeof(resolv_path)) {
         return 0;
     }
 
     if (access(resolv_path, R_OK) != 0) {
-        (void)fprintf(stderr, "[agy-termux] Missing resolver configuration: %s\n", resolv_path);
-        (void)fprintf(stderr, "[agy-termux] Install it with: pkg install resolv-conf\n");
+        (void)fprintf(stderr, "[agy-compat] Missing resolver configuration: %s\n", resolv_path);
+        if (is_termux) {
+            (void)fprintf(stderr, "[agy-termux] Install it with: pkg install resolv-conf\n");
+        }
         (void)fprintf(stderr,
-                      "[agy-termux] Without this file, login and OAuth network requests may "
+                      "[agy-compat] Without this file, login and OAuth network requests may "
                       "fail.\n");
         return 0;
     }
@@ -286,9 +288,45 @@ static int resolve_qemu_for_cpu(const char *prefix, char *qemu_path, size_t qemu
     return 0;
 }
 
+static const char *unpack_mmap_fixer(void) {
+    static char unpacked_path[PATH_MAX];
+    const char *tmp = getenv("TMPDIR");
+    if (!tmp || tmp[0] == '\0') {
+        tmp = "/tmp";
+    }
+
+    int written = snprintf(unpacked_path, sizeof(unpacked_path), "%s/libmmap_va39_fix.so", tmp);
+    if (written < 0 || written >= (int)sizeof(unpacked_path)) {
+        return NULL;
+    }
+
+    struct stat st;
+    if (stat(unpacked_path, &st) == 0 && st.st_size == (off_t)mmap_va39_fix_so_len) {
+        return unpacked_path;
+    }
+
+    FILE *fp = fopen(unpacked_path, "wb");
+    if (!fp) {
+        return NULL;
+    }
+
+    size_t written_bytes = fwrite(mmap_va39_fix_so, 1, mmap_va39_fix_so_len, fp);
+
+    if (fclose(fp) != 0 || written_bytes != mmap_va39_fix_so_len) {
+        unlink(unpacked_path);
+        return NULL;
+    }
+
+    if (chmod(unpacked_path, 0755) != 0) {
+        return NULL;
+    }
+
+    return unpacked_path;
+}
+
 int main(int argc, char **argv) {
     char exec_path[PATH_MAX];
-    char lib_path[PATH_MAX + 16];
+    char lib_path[PATH_MAX * 3];
     char patched_bin[PATH_MAX];
     char dynamic_loader[PATH_MAX];
     char cert_path[PATH_MAX];
@@ -300,50 +338,68 @@ int main(int argc, char **argv) {
     const char *qemu = NULL;
     const char *exec_target = NULL;
     const char *exec_error = NULL;
+    const char *fixer_path = NULL;
     char **new_argv = NULL;
     int arg_idx = 0;
     int written = 0;
     ssize_t read_len = 0;
+    int is_termux = is_native_termux();
 
-    if (!is_native_termux()) {
-        print_non_termux_message();
-        return 1;
-    }
+    if (is_termux) {
+        if (!resolve_qemu_for_cpu(prefix, qemu_path, sizeof(qemu_path), &qemu)) {
+            return 1;
+        }
+        written = snprintf(prefix_path, sizeof(prefix_path), "%s", prefix);
+        if (written < 0 || written >= (int)sizeof(prefix_path)) {
+            return 1;
+        }
+        written = snprintf(dynamic_loader, sizeof(dynamic_loader), "%s/glibc/lib/ld-linux-aarch64.so.1",
+                           prefix_path);
+        if (written < 0 || written >= (int)sizeof(dynamic_loader)) {
+            return 1;
+        }
+        loader = dynamic_loader;
+        exec_target = loader;
+        exec_error = "[agy-termux] execv failed";
 
-    if (!resolve_qemu_for_cpu(prefix, qemu_path, sizeof(qemu_path), &qemu)) {
-        return 1;
-    }
-    written = snprintf(prefix_path, sizeof(prefix_path), "%s", prefix);
-    if (written < 0 || written >= (int)sizeof(prefix_path)) {
-        return 1;
-    }
-    written = snprintf(dynamic_loader, sizeof(dynamic_loader), "%s/glibc/lib/ld-linux-aarch64.so.1",
-                       prefix_path);
-    if (written < 0 || written >= (int)sizeof(dynamic_loader)) {
-        return 1;
-    }
-    loader = dynamic_loader;
-    exec_target = loader;
-    exec_error = "[agy-termux] execv failed";
-
-    if (access(loader, F_OK) != 0) {
-        (void)fprintf(stderr, "[agy-termux] Missing Termux glibc loader: %s\n", loader);
-        (void)fprintf(stderr,
-                      "[agy-termux] You may need to install the glibc-repo and glibc packages.\n");
-        return 1;
+        if (access(loader, F_OK) != 0) {
+            (void)fprintf(stderr, "[agy-termux] Missing Termux glibc loader: %s\n", loader);
+            (void)fprintf(stderr,
+                          "[agy-termux] You may need to install the glibc-repo and glibc packages.\n");
+            return 1;
+        }
+    } else {
+        fixer_path = unpack_mmap_fixer();
+        if (!fixer_path) {
+            (void)fprintf(stderr, "[ERR] Failed to extract PRoot/Chroot compatibility layer.\n");
+            return 1;
+        }
+        loader = "/lib/ld-linux-aarch64.so.1";
+        exec_target = loader;
+        exec_error = "[agy-compat] execv failed";
+        if (access(loader, F_OK) != 0) {
+            (void)fprintf(stderr, "[agy-compat] Missing glibc loader: %s\n", loader);
+            return 1;
+        }
     }
 
     // Clear conflicting Android Bionic preloads and search paths.
-    unsetenv("LD_PRELOAD");
+    if (is_termux) {
+        unsetenv("LD_PRELOAD");
+    }
     unsetenv("LD_LIBRARY_PATH");
 
     // Set dynamic Go resolver and SSL configuration.
     setenv("GODEBUG", "netdns=cgo", 1);
-    written = snprintf(cert_path, sizeof(cert_path), "%s/etc/tls/cert.pem", prefix_path);
-    if (written < 0 || written >= (int)sizeof(cert_path)) {
-        return 1;
+    if (is_termux) {
+        written = snprintf(cert_path, sizeof(cert_path), "%s/etc/tls/cert.pem", prefix_path);
+        if (written < 0 || written >= (int)sizeof(cert_path)) {
+            return 1;
+        }
+        setenv("SSL_CERT_FILE", cert_path, 1);
+    } else if (access("/etc/ssl/certs/ca-certificates.crt", F_OK) == 0) {
+        setenv("SSL_CERT_FILE", "/etc/ssl/certs/ca-certificates.crt", 1);
     }
-    setenv("SSL_CERT_FILE", cert_path, 1);
 
     read_len = readlink("/proc/self/exe", exec_path, sizeof(exec_path) - 1);
     if (read_len < 0 || read_len >= (ssize_t)sizeof(exec_path)) {
@@ -356,31 +412,35 @@ int main(int argc, char **argv) {
         if (update_command_requests_help(argc, argv)) {
             return handle_update_command(dir, argc, argv);
         }
-        if (!require_resolver_config(prefix_path)) {
+        if (!require_resolver_config(prefix_path, is_termux)) {
             return 1;
         }
         return handle_update_command(dir, argc, argv);
     }
 
-    if (!require_resolver_config(prefix_path)) {
+    if (!require_resolver_config(prefix_path, is_termux)) {
         return 1;
     }
 
-    // Use only the Termux glibc runtime libraries.
-    written = snprintf(lib_path, sizeof(lib_path), "%s/glibc/lib", prefix_path);
+    // Construct relocatable library search path.
+    if (is_termux) {
+        written = snprintf(lib_path, sizeof(lib_path), "%s/../lib:%s/glibc/lib", dir, prefix_path);
+    } else {
+        written = snprintf(lib_path, sizeof(lib_path), "%s/../lib:/lib/aarch64-linux-gnu:/usr/lib/aarch64-linux-gnu", dir);
+    }
     if (written < 0 || written >= (int)sizeof(lib_path)) {
         return 1;
     }
 
-    // Construct path to the patched binary
+    // Construct path to the patched binary.
     written = snprintf(patched_bin, sizeof(patched_bin), "%s/agy.va39", dir);
     if (written < 0 || written >= (int)sizeof(patched_bin)) {
         return 1;
     }
 
-    // We allocate enough space for: qemu + loader + "--library-path" + lib_path
+    // We allocate enough space for: qemu + loader + "--preload" + fixer_path + "--library-path" + lib_path
     // + patched_bin + user args + NULL
-    int new_argc = argc + 6;
+    int new_argc = argc + 10;
     new_argv = malloc((size_t)new_argc * sizeof(*new_argv));
     if (!new_argv) {
         return 1;
@@ -393,6 +453,10 @@ int main(int argc, char **argv) {
         exec_error = "[agy-termux] execv (qemu) failed";
     }
     new_argv[arg_idx++] = (char *)loader;
+    if (fixer_path) {
+        new_argv[arg_idx++] = "--preload";
+        new_argv[arg_idx++] = (char *)fixer_path;
+    }
     new_argv[arg_idx++] = "--library-path";
     new_argv[arg_idx++] = lib_path;
     new_argv[arg_idx++] = patched_bin;

--- a/lib/agy_helper.c
+++ b/lib/agy_helper.c
@@ -301,23 +301,47 @@ static const char *unpack_mmap_fixer(void) {
     }
 
     struct stat st;
-    if (stat(unpacked_path, &st) == 0 && st.st_size == (off_t)mmap_va39_fix_so_len) {
-        return unpacked_path;
+    if (stat(unpacked_path, &st) == 0) {
+        if (S_ISREG(st.st_mode) && st.st_uid == getuid() && st.st_size == (off_t)mmap_va39_fix_so_len) {
+            return unpacked_path;
+        }
     }
 
-    FILE *fp = fopen(unpacked_path, "wb");
-    if (!fp) {
+    char temp_template[PATH_MAX];
+    int temp_written = snprintf(temp_template, sizeof(temp_template), "%s/libmmap_va39_fix.tmp.XXXXXX", tmp);
+    if (temp_written < 0 || temp_written >= (int)sizeof(temp_template)) {
         return NULL;
     }
 
-    size_t written_bytes = fwrite(mmap_va39_fix_so, 1, mmap_va39_fix_so_len, fp);
-
-    if (fclose(fp) != 0 || written_bytes != mmap_va39_fix_so_len) {
-        unlink(unpacked_path);
+    int fd = mkstemp(temp_template);
+    if (fd < 0) {
         return NULL;
     }
 
-    if (chmod(unpacked_path, 0755) != 0) {
+    size_t total_written = 0;
+    while (total_written < mmap_va39_fix_so_len) {
+        ssize_t written_bytes = write(fd, mmap_va39_fix_so + total_written, mmap_va39_fix_so_len - total_written);
+        if (written_bytes < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(fd);
+            unlink(temp_template);
+            return NULL;
+        }
+        total_written += (size_t)written_bytes;
+    }
+
+    if (fchmod(fd, 0755) != 0) {
+        close(fd);
+        unlink(temp_template);
+        return NULL;
+    }
+
+    close(fd);
+
+    if (rename(temp_template, unpacked_path) != 0) {
+        unlink(temp_template);
         return NULL;
     }
 

--- a/lib/mmap_va39_fix.c
+++ b/lib/mmap_va39_fix.c
@@ -1,0 +1,41 @@
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+/*
+ * TCMalloc assumes a 48-bit Virtual Address (VA) space.
+ * Many ARM64 Android kernels (and chroots running on them) are limited to 39 bits.
+ * This interposer intercepts mmap calls and clears the hint address if it
+ * exceeds the 39-bit boundary, allowing the kernel to pick a safe address.
+ */
+
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
+enum { max_va_bits = 39 };
+static const uintptr_t va_boundary = (uintptr_t)1 << max_va_bits;
+
+// NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name)
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    static void *(*real_mmap)(void *, size_t, int, int, int, off_t) = NULL;
+    if (!real_mmap) {
+        void *symbol = dlsym(RTLD_NEXT, "mmap");
+        memcpy(&real_mmap, &symbol, sizeof(real_mmap));
+    }
+
+    int is_fixed = (flags & MAP_FIXED) != 0;
+#ifdef MAP_FIXED_NOREPLACE
+    is_fixed = is_fixed || (flags & MAP_FIXED_NOREPLACE) != 0;
+#endif
+
+    if (!is_fixed && (uintptr_t)addr >= va_boundary) {
+        addr = NULL;
+    }
+
+    return real_mmap(addr, length, prot, flags, fd, offset);
+}


### PR DESCRIPTION
## Summary

This pull request restores compatibility with Ubuntu chroot/PRoot guest environments and resolves a build failure when compiling the native bootstrapper wrapper (`lib/agy_helper.c`) in environments where the Android NDK compiler wrapper is symlinked to the host compiler.

---

## Detailed Rationale & Context

### 1. Restoration of Chroot/PRoot Compatibility Layer
Prior to the flattening of the release archive in commit `25500f5` (PR #23), the bootstrapper acted as a bridge for guest Linux environments (like Ubuntu chroots) running on 39-bit Virtual Address (VA) Android kernels. It did this by unpacking and preloading the memory allocator interposer `libmmap_va39_fix.so` to prevent memory allocation faults under TCMalloc.

Since PRoot/Chroot support was stripped, running `./bin/agy` directly on Ubuntu failed because:
1. The codebase unconditionally exited with `This standalone port is only for native Termux.` when `is_native_termux()` returned false.
2. The compatibility layer to unpack and preload `libmmap_va39_fix.so` was removed.

**Fix**: Restored the unpacking and preloading logic in [agy_helper.c](file:///root/Projects/antigravity-cli-termux/lib/agy_helper.c) and recreated [mmap_va39_fix.c](file:///root/Projects/antigravity-cli-termux/lib/mmap_va39_fix.c). If executed outside of native Termux, the bootstrapper automatically falls back to guest mode, unsets conflicting preloads/paths, preloads the VA39 fix, and runs the dynamic loader.

### 2. NDK Symlinked Host Compiler Compilation Fixes
When compiling with the Android NDK on an ARM64 host, many setups symlink the NDK's `clang` wrapper to the host's `/usr/bin/clang-18` (because the NDK's original compiler is an `x86-64` binary which throws `Exec format error` on ARM64).

However, using host `clang` with NDK target parameters causes the compiler driver to look for `libgcc` inside host system paths (like `/usr/lib/llvm-18/...`), leading to the following link error:
`ld.lld: error: unable to find library -lgcc`

**Fix**: Updated [build.sh](file:///root/Projects/antigravity-cli-termux/build.sh) to automatically detect if it is compiling with the NDK. If so, it dynamically resolves the NDK's resource directory and passes the following flags:
`--rtlib=compiler-rt -unwindlib=libunwind -resource-dir <ndk_resource_dir>`
This tells Clang to link `libclang_rt.builtins-aarch64-android.a` and `libunwind.a` from the NDK instead of looking for `libgcc.a` on the host system.

### 3. Native Host Compilation Option (`USE_NDK=0`)
If a developer has the NDK installed but wants to build a native Ubuntu binary, the build script previously forced the use of the NDK. We have restored host compiler detection (`clang`/`gcc` fallback) and supported unsetting/bypassing NDK compiler detection using:
```bash
USE_NDK=0 ./build.sh
```

### 4. Automatic `SSL_CERT_FILE` Path Fallback
In chroot guest environments, `curl` inside `build.sh` failed because it inherited `SSL_CERT_FILE` pointing to a Termux-specific directory that is inaccessible inside the chroot.
We added an automatic check to [build.sh](file:///root/Projects/antigravity-cli-termux/build.sh): if `SSL_CERT_FILE` is set but points to a non-existent path, it is automatically unset so `curl` falls back to the host system certificates.

---

## Changes

* **`build.sh`**:
  * Added automatic verification and cleanup of invalid `SSL_CERT_FILE` variables.
  * Restored host compiler PATH checks (`clang` / `gcc`).
  * Supported `USE_NDK=0` flag to bypass the NDK compiler and target the host.
  * Resolved the `libgcc` linker error by passing compiler-rt and resource-dir flags when using the NDK.
* **`lib/agy_helper.c`**:
  * Restored compatibility layer to run on Ubuntu guest chroots.
  * Replaced the unconditional exit check with dynamic Termux vs Guest environment resolution.
  * Added automatic unpacking of `libmmap_va39_fix.so` and dynamic linker preload mapping.
* **`lib/mmap_va39_fix.c`**:
  * Re-added the interposer source code for completeness.

---

## Testing / Verification

### NDK Target Build (Termux Bionic binary):
```bash
./build.sh
file bin/agy
# Output: ELF 64-bit LSB pie executable, ARM aarch64, interpreter /system/bin/linker64
```

### Native Host Target Build (Ubuntu glibc binary):
```bash
USE_NDK=0 ./build.sh
file bin/agy
# Output: ELF 64-bit LSB pie executable, ARM aarch64, interpreter /lib/ld-linux-aarch64.so.1

./bin/agy --version
# Output: 1.0.16
```
